### PR TITLE
Common: Remove logger dependency on process object

### DIFF
--- a/packages/common/src/logging/logger.ts
+++ b/packages/common/src/logging/logger.ts
@@ -1,7 +1,15 @@
 export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
 
 export interface ILoggerOptions {
+  /**
+   * Minimum severity level to log. When provided, log entries with lower severity are ignored.
+   */
   readonly level?: LogLevel;
+  /**
+   * Logger name filter pattern. May contain wild cards.
+   * When provided, the logger is only enabled if its name matches the pattern.
+   */
+  readonly pattern?: string;
 }
 
 export interface ILogger {


### PR DESCRIPTION
This updates the ConsoleLogger class to 
a) take logger name pattern as an optional parameter to the constructor, 
b) take log level from `process.env` when available, and 
c) be resilient to the process instance being unavailable.
For both logger & pattern options, the environment value is favored over the logger options.