### PR TITLE
Add sign in options

### DIFF
--- a/packages/apps/src/contexts/activity.ts
+++ b/packages/apps/src/contexts/activity.ts
@@ -219,7 +219,7 @@ export class ActivityContext<T extends Activity = Activity> implements IActivity
         members: [this.activity.from],
       });
 
-      await this.send({ type: 'message', text });
+      await this.send({ type: 'message', text: oauthCardText });
       convo.conversation = { id: res.id } as ConversationAccount;
     }
 


### PR DESCRIPTION
This is a fairly minor (but breaking) interface change. 

1. It changes "name" to "connectionName" which is more clear
2. It adds further options to customize the oauth card
3. It moves options to a partial object for `signin` << this is the breaking change.

I found that these changes made it easier for me to understand what was going on. Happy to remove the breaking change if that's preferred.