### PR TITLE
[cli] Update basic tab template to support dynamic redirect Uri

### DIFF
--- a/packages/cli/configs/ttk/basic/aad.manifest.json.hbs
+++ b/packages/cli/configs/ttk/basic/aad.manifest.json.hbs
@@ -1,0 +1,112 @@
+{
+    "id": "$\{{AAD_APP_OBJECT_ID}}",
+    "appId": "$\{{BOT_ID}}",
+    "displayName": "{{ toPascalCase name }}$\{{APP_NAME_SUFFIX}}",
+    "identifierUris": [
+        "api://$\{{BOT_DOMAIN}}/$\{{BOT_ID}}"
+    ],
+    "signInAudience": "AzureADMultipleOrgs",
+    "api": {
+        "requestedAccessTokenVersion": 2,
+        "oauth2PermissionScopes": [
+            {
+                "adminConsentDescription": "Allows Teams to call the app's web APIs as the current user.",
+                "adminConsentDisplayName": "Teams can access app's web APIs",
+                "id": "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}",
+                "isEnabled": true,
+                "type": "User",
+                "userConsentDescription": "Enable Teams to call this app's web APIs with the same rights that you have",
+                "userConsentDisplayName": "Teams can access app's web APIs and make requests on your behalf",
+                "value": "access_as_user"
+            }
+        ],
+        "preAuthorizedApplications": [
+            {
+                "appId": "1fec8e78-bce4-4aaf-ab1b-5451cc387264",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "5e3ce6c0-2b1f-4285-8d4b-75ee78787346",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "d3590ed6-52b3-4102-aeff-aad2292ab01c",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "00000002-0000-0ff1-ce00-000000000000",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "bc59ab01-8403-45c6-8796-ac3ef710b3e3",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "0ec893e0-5785-4de6-99da-4ed124e5296c",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "4765445b-32c6-49b0-83e6-1d93765276ca",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "4345a7b9-9a63-4910-a426-35363201d503",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            },
+            {
+                "appId": "27922004-5251-4030-b22d-91ecd9a37ea4",
+                "delegatedPermissionIds": [
+                    "$\{{AAD_APP_ACCESS_AS_USER_PERMISSION_ID}}"
+                ]
+            }
+        ]
+    },
+    "info": {},
+    "optionalClaims": {
+        "idToken": [],
+        "accessToken": [
+            {
+                "name": "idtyp",
+                "source": null,
+                "essential": false,
+                "additionalProperties": []
+            }
+        ],
+        "saml2Token": []
+    },
+    "publicClient": {
+        "redirectUris": []
+    },
+    "requiredResourceAccess": [
+        {
+            "resourceAppId": "Microsoft Graph",
+            "resourceAccess": [
+                {
+                    "id": "User.Read",
+                    "type": "Scope"
+                }
+            ]
+        }
+    ],
+    "spa": {
+        "redirectUris": [
+            "brk-multihub://$\{{BOT_DOMAIN}}"
+        ]
+    }
+}

--- a/packages/cli/configs/ttk/basic/teamsapp.local.yml.hbs
+++ b/packages/cli/configs/ttk/basic/teamsapp.local.yml.hbs
@@ -12,21 +12,36 @@ environmentFolderPath: ./env
 # Defines what the `provision` lifecycle step does with Teams Toolkit.
 # Runs first during Start Debugging (F5) or run manually using `teamsfx provision --env local`.
 provision:
+  - uses: aadApp/create
+    with:
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
+      # based on the definition in manifest. If you don't want to change the
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
+      # defined here.
+      name: {{ toPascalCase name }}
+      # If the value is false, the action will not generate client secret for you
+      generateClientSecret: true
+      # Authenticate users with a Microsoft work or school account in your
+      # organization's Microsoft Entra tenant (for example, single tenant).
+      signInAudience: AzureADMultipleOrgs
+    # Write the information of created resources into environment file for the
+    # specified environment variable(s).
+    writeToEnvironmentFile:
+      clientId: BOT_ID
+      # Environment variable that starts with `SECRET_` will be stored to the
+      # .env.{envName}.user environment file
+      clientSecret: SECRET_BOT_PASSWORD
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
+
   # Automates the creation of a Teams app registration and saves the App ID to an environment file.
   - uses: teamsApp/create
     with:
         name: {{ toPascalCase name }}$\{{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
         teamsAppId: TEAMS_APP_ID
-
-  # Automates the creation an Azure AD app registration which is required for a bot.
-  # The Bot ID (AAD app client ID) and Bot Password (AAD app client secret) are saved to an environment file.
-  - uses: botAadApp/create
-    with:
-        name: {{ toPascalCase name }}$\{{APP_NAME_SUFFIX}}
-    writeToEnvironmentFile:
-        botId: BOT_ID
-        botPassword: SECRET_BOT_PASSWORD
 
   # Automates the creation and configuration of a Bot Framework registration which is required for a bot.
   # This configures the bot to use the Azure AD app registration created in the previous step.
@@ -39,6 +54,13 @@ provision:
         description: ''
         channels:
             - name: msteams
+
+  - uses: aadApp/update
+    with:
+      # Relative path to this file. Environment variables in manifest will
+      # be replaced before apply to Microsoft Entra app
+      manifestPath: ./aad.manifest.json
+      outputFilePath: ./build/aad.manifest.$\{{TEAMSFX_ENV}}.json
 
   # Optional: Automates schema and error checking of the Teams app manifest and outputs the results in the console.
   - uses: teamsApp/validateManifest

--- a/packages/cli/configs/ttk/basic/teamsapp.yml.hbs
+++ b/packages/cli/configs/ttk/basic/teamsapp.yml.hbs
@@ -13,21 +13,36 @@ environmentFolderPath: ./env
 # Defines what the `provision` lifecycle step does with Teams Toolkit.
 # Runs with the Provision menu or CLI using `teamsfx provision --env {environment name}`.
 provision:
+  - uses: aadApp/create
+    with:
+      # Note: when you run aadApp/update, the Microsoft Entra app name will be updated
+      # based on the definition in manifest. If you don't want to change the
+      # name, make sure the name in Microsoft Entra manifest is the same with the name
+      # defined here.
+      name: {{ toPascalCase name }}
+      # If the value is false, the action will not generate client secret for you
+      generateClientSecret: true
+      # Authenticate users with a Microsoft work or school account in your
+      # organization's Microsoft Entra tenant (for example, single tenant).
+      signInAudience: AzureADMultipleOrgs
+    # Write the information of created resources into environment file for the
+    # specified environment variable(s).
+    writeToEnvironmentFile:
+      clientId: BOT_ID
+      # Environment variable that starts with `SECRET_` will be stored to the
+      # .env.{envName}.user environment file
+      clientSecret: SECRET_BOT_PASSWORD
+      objectId: AAD_APP_OBJECT_ID
+      tenantId: AAD_APP_TENANT_ID
+      authority: AAD_APP_OAUTH_AUTHORITY
+      authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
+
   # Automates the creation of a Teams app registration and saves the App ID to an environment file.
   - uses: teamsApp/create
     with:
       name: {{ toPascalCase name }}$\{{APP_NAME_SUFFIX}}
     writeToEnvironmentFile:
       teamsAppId: TEAMS_APP_ID
-
-  # Automates the creation an Azure AD app registration which is required for a bot.
-  # The Bot ID (AAD app client ID) and Bot Password (AAD app client secret) are saved to an environment file.
-  - uses: botAadApp/create
-    with:
-      name: {{ toPascalCase name }}$\{{APP_NAME_SUFFIX}}
-    writeToEnvironmentFile:
-      botId: BOT_ID
-      botPassword: SECRET_BOT_PASSWORD
 
   # Automates the creation of infrastructure defined in ARM templates to host the bot.
   # The created resource IDs are saved to an environment file.
@@ -40,6 +55,13 @@ provision:
           parameters: ./infra/azure.parameters.json
           deploymentName: Create-resources-for-tab
       bicepCliVersion: v0.9.1
+
+  - uses: aadApp/update
+    with:
+      # Relative path to this file. Environment variables in manifest will
+      # be replaced before apply to Microsoft Entra app
+      manifestPath: ./aad.manifest.json
+      outputFilePath: ./build/aad.manifest.$\{{TEAMSFX_ENV}}.json
 
   # Optional: Automates schema and error checking of the Teams app manifest and outputs the results in the console.
   - uses: teamsApp/validateManifest


### PR DESCRIPTION
This updates the basic tab template so that the app registration SPA redirect URI is updated to match the dynamic tunnel name when running locally. This to set up for supporting NAA next.

This switches the yaml templates from using `botAadApp/create` to `aadApp/create` to create the app registration, just to get the object ID variable really - to allow using `aadApp/update` to update the redirect URI. 

How tested:
 - built the cli locally; created a new app using the template; ran that app in Teams using TTK; verified on the Azure app registration that the tunnel is set correct, and that I can chat with the bot.