### PR TITLE
Handle ref params for parameters

### DIFF
--- a/packages/graph/src/appCatalogs/teamsApps/appDefinitions/index.ts
+++ b/packages/graph/src/appCatalogs/teamsApps/appDefinitions/index.ts
@@ -119,6 +119,11 @@ export class AppDefinitionsClient {
     const url = getInjectedUrl(
       '/appCatalogs/teamsApps/{teamsApp-id}/appDefinitions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/appCatalogs/teamsApps/index.ts
+++ b/packages/graph/src/appCatalogs/teamsApps/index.ts
@@ -114,6 +114,11 @@ export class TeamsAppsClient {
     const url = getInjectedUrl(
       '/appCatalogs/teamsApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/appRoleAssignments/index.ts
+++ b/packages/graph/src/appRoleAssignments/index.ts
@@ -183,6 +183,11 @@ export class AppRoleAssignmentsClient {
     const url = getInjectedUrl(
       '/appRoleAssignments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applicationTemplates/index.ts
+++ b/packages/graph/src/applicationTemplates/index.ts
@@ -87,6 +87,11 @@ export class ApplicationTemplatesClient {
     const url = getInjectedUrl(
       '/applicationTemplates',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/appManagementPolicies.ts
+++ b/packages/graph/src/applications/appManagementPolicies.ts
@@ -80,6 +80,11 @@ export class AppManagementPoliciesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/appManagementPolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/extensionProperties.ts
+++ b/packages/graph/src/applications/extensionProperties.ts
@@ -110,6 +110,11 @@ export class ExtensionPropertiesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/extensionProperties',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/federatedIdentityCredentials.ts
+++ b/packages/graph/src/applications/federatedIdentityCredentials.ts
@@ -110,6 +110,11 @@ export class FederatedIdentityCredentialsClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/federatedIdentityCredentials',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/homeRealmDiscoveryPolicies.ts
+++ b/packages/graph/src/applications/homeRealmDiscoveryPolicies.ts
@@ -79,6 +79,11 @@ export class HomeRealmDiscoveryPoliciesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/homeRealmDiscoveryPolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/index.ts
+++ b/packages/graph/src/applications/index.ts
@@ -340,6 +340,11 @@ export class ApplicationsClient {
       '/applications',
       [
         { name: 'ConsistencyLevel', in: 'header' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/owners.ts
+++ b/packages/graph/src/applications/owners.ts
@@ -81,6 +81,11 @@ export class OwnersClient {
       '/applications/{application-id}/owners',
       [
         { name: 'ConsistencyLevel', in: 'header' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/synchronization/jobs/index.ts
+++ b/packages/graph/src/applications/synchronization/jobs/index.ts
@@ -175,6 +175,11 @@ export class JobsClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/synchronization/jobs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/synchronization/jobs/schema/directories/index.ts
+++ b/packages/graph/src/applications/synchronization/jobs/schema/directories/index.ts
@@ -117,6 +117,11 @@ export class DirectoriesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/synchronization/jobs/{synchronizationJob-id}/schema/directories',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/synchronization/templates/index.ts
+++ b/packages/graph/src/applications/synchronization/templates/index.ts
@@ -115,6 +115,11 @@ export class TemplatesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/synchronization/templates',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/synchronization/templates/schema/directories/index.ts
+++ b/packages/graph/src/applications/synchronization/templates/schema/directories/index.ts
@@ -117,6 +117,11 @@ export class DirectoriesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/synchronization/templates/{synchronizationTemplate-id}/schema/directories',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/tokenIssuancePolicies.ts
+++ b/packages/graph/src/applications/tokenIssuancePolicies.ts
@@ -80,6 +80,11 @@ export class TokenIssuancePoliciesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/tokenIssuancePolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/applications/tokenLifetimePolicies.ts
+++ b/packages/graph/src/applications/tokenLifetimePolicies.ts
@@ -80,6 +80,11 @@ export class TokenLifetimePoliciesClient {
     const url = getInjectedUrl(
       '/applications/{application-id}/tokenLifetimePolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/index.ts
+++ b/packages/graph/src/chats/index.ts
@@ -219,6 +219,11 @@ export class ChatsClient {
     const url = getInjectedUrl(
       '/chats',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/installedApps/index.ts
+++ b/packages/graph/src/chats/installedApps/index.ts
@@ -140,6 +140,11 @@ export class InstalledAppsClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/installedApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/members/index.ts
+++ b/packages/graph/src/chats/members/index.ts
@@ -130,6 +130,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/messages/hostedContents.ts
+++ b/packages/graph/src/chats/messages/hostedContents.ts
@@ -110,6 +110,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/messages/{chatMessage-id}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/messages/index.ts
+++ b/packages/graph/src/chats/messages/index.ts
@@ -169,6 +169,11 @@ export class MessagesClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/messages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/messages/replies/hostedContents.ts
+++ b/packages/graph/src/chats/messages/replies/hostedContents.ts
@@ -112,6 +112,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/messages/replies/index.ts
+++ b/packages/graph/src/chats/messages/replies/index.ts
@@ -160,6 +160,11 @@ export class RepliesClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/messages/{chatMessage-id}/replies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/permissionGrants.ts
+++ b/packages/graph/src/chats/permissionGrants.ts
@@ -109,6 +109,11 @@ export class PermissionGrantsClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/permissionGrants',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/pinnedMessages/index.ts
+++ b/packages/graph/src/chats/pinnedMessages/index.ts
@@ -120,6 +120,11 @@ export class PinnedMessagesClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/pinnedMessages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/chats/tabs/index.ts
+++ b/packages/graph/src/chats/tabs/index.ts
@@ -119,6 +119,11 @@ export class TabsClient {
     const url = getInjectedUrl(
       '/chats/{chat-id}/tabs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },
@@ -166,7 +171,7 @@ export class TabsClient {
   /**
    * `PATCH /chats/{chat-id}/tabs/{teamsTab-id}`
    *
-   * Update the properties of the specified tab in a chat.
+   * Update the properties of the specified tab in a chat. 
 This can be used to configure the content of the tab.
    */
   async update(
@@ -196,7 +201,7 @@ This can be used to configure the content of the tab.
   /**
    * `POST /chats/{chat-id}/tabs`
    *
-   * Add (pin) a tab to the specified chat.
+   * Add (pin) a tab to the specified chat. 
 The corresponding app must already be installed in the chat.
    */
   async create(

--- a/packages/graph/src/communications/callRecords/index.ts
+++ b/packages/graph/src/communications/callRecords/index.ts
@@ -114,6 +114,11 @@ export class CallRecordsClient {
     const url = getInjectedUrl(
       '/communications/callRecords',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/callRecords/sessions/index.ts
+++ b/packages/graph/src/communications/callRecords/sessions/index.ts
@@ -119,6 +119,11 @@ export class SessionsClient {
     const url = getInjectedUrl(
       '/communications/callRecords/{callRecord-id}/sessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/callRecords/sessions/segments.ts
+++ b/packages/graph/src/communications/callRecords/sessions/segments.ts
@@ -110,6 +110,11 @@ export class SegmentsClient {
     const url = getInjectedUrl(
       '/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/calls/audioRoutingGroups.ts
+++ b/packages/graph/src/communications/calls/audioRoutingGroups.ts
@@ -110,6 +110,11 @@ export class AudioRoutingGroupsClient {
     const url = getInjectedUrl(
       '/communications/calls/{call-id}/audioRoutingGroups',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/calls/contentSharingSessions.ts
+++ b/packages/graph/src/communications/calls/contentSharingSessions.ts
@@ -109,6 +109,11 @@ export class ContentSharingSessionsClient {
     const url = getInjectedUrl(
       '/communications/calls/{call-id}/contentSharingSessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/calls/index.ts
+++ b/packages/graph/src/communications/calls/index.ts
@@ -302,6 +302,11 @@ export class CallsClient {
     const url = getInjectedUrl(
       '/communications/calls',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/calls/operations.ts
+++ b/packages/graph/src/communications/calls/operations.ts
@@ -109,6 +109,11 @@ export class OperationsClient {
     const url = getInjectedUrl(
       '/communications/calls/{call-id}/operations',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/calls/participants/index.ts
+++ b/packages/graph/src/communications/calls/participants/index.ts
@@ -150,6 +150,11 @@ export class ParticipantsClient {
     const url = getInjectedUrl(
       '/communications/calls/{call-id}/participants',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/onlineMeetings/attendanceReports/attendanceRecords.ts
+++ b/packages/graph/src/communications/onlineMeetings/attendanceReports/attendanceRecords.ts
@@ -111,6 +111,11 @@ export class AttendanceRecordsClient {
     const url = getInjectedUrl(
       '/communications/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/onlineMeetings/attendanceReports/index.ts
+++ b/packages/graph/src/communications/onlineMeetings/attendanceReports/index.ts
@@ -119,6 +119,11 @@ export class AttendanceReportsClient {
     const url = getInjectedUrl(
       '/communications/onlineMeetings/{onlineMeeting-id}/attendanceReports',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/onlineMeetings/index.ts
+++ b/packages/graph/src/communications/onlineMeetings/index.ts
@@ -174,6 +174,11 @@ export class OnlineMeetingsClient {
     const url = getInjectedUrl(
       '/communications/onlineMeetings',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/onlineMeetings/recordings/index.ts
+++ b/packages/graph/src/communications/onlineMeetings/recordings/index.ts
@@ -119,6 +119,11 @@ export class RecordingsClient {
     const url = getInjectedUrl(
       '/communications/onlineMeetings/{onlineMeeting-id}/recordings',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/onlineMeetings/transcripts/index.ts
+++ b/packages/graph/src/communications/onlineMeetings/transcripts/index.ts
@@ -129,6 +129,11 @@ export class TranscriptsClient {
     const url = getInjectedUrl(
       '/communications/onlineMeetings/{onlineMeeting-id}/transcripts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/communications/presences/index.ts
+++ b/packages/graph/src/communications/presences/index.ts
@@ -153,6 +153,11 @@ export class PresencesClient {
     const url = getInjectedUrl(
       '/communications/presences',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/employeeExperience/learningProviders/index.ts
+++ b/packages/graph/src/employeeExperience/learningProviders/index.ts
@@ -125,6 +125,11 @@ export class LearningProvidersClient {
     const url = getInjectedUrl(
       '/employeeExperience/learningProviders',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/employeeExperience/learningProviders/learningContents.ts
+++ b/packages/graph/src/employeeExperience/learningProviders/learningContents.ts
@@ -111,6 +111,11 @@ export class LearningContentsClient {
     const url = getInjectedUrl(
       '/employeeExperience/learningProviders/{learningProvider-id}/learningContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/employeeExperience/learningProviders/learningCourseActivities.ts
+++ b/packages/graph/src/employeeExperience/learningProviders/learningCourseActivities.ts
@@ -111,6 +111,11 @@ export class LearningCourseActivitiesClient {
     const url = getInjectedUrl(
       '/employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },
@@ -193,7 +198,7 @@ export class LearningCourseActivitiesClient {
   /**
    * `POST /employeeExperience/learningProviders/{learningProvider-id}/learningCourseActivities`
    *
-   * Create a new learningCourseActivity object. A learning course activity can be one of two types:
+   * Create a new learningCourseActivity object. A learning course activity can be one of two types: 
 - Assignment
 - Self-initiated Use this method to create either type of activity.
    */

--- a/packages/graph/src/me/calendar/calendarPermissions.ts
+++ b/packages/graph/src/me/calendar/calendarPermissions.ts
@@ -104,6 +104,11 @@ export class CalendarPermissionsClient {
     const url = getInjectedUrl(
       '/me/calendar/calendarPermissions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/calendarView/attachments/index.ts
+++ b/packages/graph/src/me/calendar/calendarView/attachments/index.ts
@@ -119,6 +119,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendar/calendarView/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/calendarView/cancel.ts
+++ b/packages/graph/src/me/calendar/calendarView/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendar/calendarView/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendar/calendarView/extensions.ts
+++ b/packages/graph/src/me/calendar/calendarView/extensions.ts
@@ -109,6 +109,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendar/calendarView/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/calendarView/index.ts
+++ b/packages/graph/src/me/calendar/calendarView/index.ts
@@ -190,6 +190,11 @@ from a user&#x27;s default calendar (../me/calendarView) or some other calendar 
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/calendarView/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendar/calendarView/instances/attachments/index.ts
@@ -120,6 +120,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendar/calendarView/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/calendarView/instances/cancel.ts
+++ b/packages/graph/src/me/calendar/calendarView/instances/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendar/calendarView/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendar/calendarView/instances/extensions.ts
+++ b/packages/graph/src/me/calendar/calendarView/instances/extensions.ts
@@ -110,6 +110,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendar/calendarView/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/calendarView/instances/index.ts
+++ b/packages/graph/src/me/calendar/calendarView/instances/index.ts
@@ -182,6 +182,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/events/attachments/index.ts
+++ b/packages/graph/src/me/calendar/events/attachments/index.ts
@@ -119,6 +119,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendar/events/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/events/cancel.ts
+++ b/packages/graph/src/me/calendar/events/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendar/events/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendar/events/extensions.ts
+++ b/packages/graph/src/me/calendar/events/extensions.ts
@@ -109,6 +109,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendar/events/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/events/index.ts
+++ b/packages/graph/src/me/calendar/events/index.ts
@@ -212,6 +212,11 @@ get the instances of an event.
     const url = getInjectedUrl(
       '/me/calendar/events',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/events/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendar/events/instances/attachments/index.ts
@@ -120,6 +120,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendar/events/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/events/instances/cancel.ts
+++ b/packages/graph/src/me/calendar/events/instances/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendar/events/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendar/events/instances/extensions.ts
+++ b/packages/graph/src/me/calendar/events/instances/extensions.ts
@@ -110,6 +110,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendar/events/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendar/events/instances/index.ts
+++ b/packages/graph/src/me/calendar/events/instances/index.ts
@@ -182,6 +182,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarPermissions.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarPermissions.ts
@@ -111,6 +111,11 @@ export class CalendarPermissionsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarPermissions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/attachments/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/attachments/index.ts
@@ -122,6 +122,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/cancel.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/cancel.ts
@@ -72,7 +72,7 @@ export class CancelClient {
   /**
    * `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/extensions.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/extensions.ts
@@ -112,6 +112,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/index.ts
@@ -192,6 +192,11 @@ export class CalendarViewClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/attachments/index.ts
@@ -123,6 +123,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/cancel.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/cancel.ts
@@ -72,7 +72,7 @@ export class CancelClient {
   /**
    * `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/extensions.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/extensions.ts
@@ -113,6 +113,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/calendarView/instances/index.ts
@@ -183,6 +183,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/events/attachments/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/attachments/index.ts
@@ -122,6 +122,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/events/cancel.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/cancel.ts
@@ -72,7 +72,7 @@ export class CancelClient {
   /**
    * `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendarGroups/calendars/events/extensions.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/extensions.ts
@@ -112,6 +112,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/events/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/index.ts
@@ -220,6 +220,11 @@ export class EventsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/events/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/instances/attachments/index.ts
@@ -123,6 +123,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/events/instances/cancel.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/instances/cancel.ts
@@ -72,7 +72,7 @@ export class CancelClient {
   /**
    * `POST /me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendarGroups/calendars/events/instances/extensions.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/instances/extensions.ts
@@ -113,6 +113,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/events/instances/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/events/instances/index.ts
@@ -183,6 +183,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/calendars/index.ts
+++ b/packages/graph/src/me/calendarGroups/calendars/index.ts
@@ -149,6 +149,11 @@ export class CalendarsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups/{calendarGroup-id}/calendars',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarGroups/index.ts
+++ b/packages/graph/src/me/calendarGroups/index.ts
@@ -114,6 +114,11 @@ export class CalendarGroupsClient {
     const url = getInjectedUrl(
       '/me/calendarGroups',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarView/attachments/index.ts
+++ b/packages/graph/src/me/calendarView/attachments/index.ts
@@ -119,6 +119,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendarView/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarView/cancel.ts
+++ b/packages/graph/src/me/calendarView/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendarView/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendarView/extensions.ts
+++ b/packages/graph/src/me/calendarView/extensions.ts
@@ -109,6 +109,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendarView/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarView/index.ts
+++ b/packages/graph/src/me/calendarView/index.ts
@@ -187,6 +187,11 @@ or from some other calendar of the user.
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarView/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendarView/instances/attachments/index.ts
@@ -120,6 +120,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendarView/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarView/instances/cancel.ts
+++ b/packages/graph/src/me/calendarView/instances/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendarView/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendarView/instances/extensions.ts
+++ b/packages/graph/src/me/calendarView/instances/extensions.ts
@@ -110,6 +110,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendarView/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendarView/instances/index.ts
+++ b/packages/graph/src/me/calendarView/instances/index.ts
@@ -182,6 +182,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarPermissions.ts
+++ b/packages/graph/src/me/calendars/calendarPermissions.ts
@@ -109,6 +109,11 @@ export class CalendarPermissionsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/calendarPermissions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarView/attachments/index.ts
+++ b/packages/graph/src/me/calendars/calendarView/attachments/index.ts
@@ -120,6 +120,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/calendarView/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarView/cancel.ts
+++ b/packages/graph/src/me/calendars/calendarView/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendars/{calendar-id}/calendarView/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendars/calendarView/extensions.ts
+++ b/packages/graph/src/me/calendars/calendarView/extensions.ts
@@ -110,6 +110,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/calendarView/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarView/index.ts
+++ b/packages/graph/src/me/calendars/calendarView/index.ts
@@ -192,6 +192,11 @@ export class CalendarViewClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarView/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendars/calendarView/instances/attachments/index.ts
@@ -122,6 +122,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarView/instances/cancel.ts
+++ b/packages/graph/src/me/calendars/calendarView/instances/cancel.ts
@@ -72,7 +72,7 @@ export class CancelClient {
   /**
    * `POST /me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendars/calendarView/instances/extensions.ts
+++ b/packages/graph/src/me/calendars/calendarView/instances/extensions.ts
@@ -112,6 +112,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/calendarView/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/calendarView/instances/index.ts
+++ b/packages/graph/src/me/calendars/calendarView/instances/index.ts
@@ -182,6 +182,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/events/attachments/index.ts
+++ b/packages/graph/src/me/calendars/events/attachments/index.ts
@@ -120,6 +120,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/events/{event-id}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/events/cancel.ts
+++ b/packages/graph/src/me/calendars/events/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendars/{calendar-id}/events/{event-id}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendars/events/extensions.ts
+++ b/packages/graph/src/me/calendars/events/extensions.ts
@@ -110,6 +110,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/events/{event-id}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/events/index.ts
+++ b/packages/graph/src/me/calendars/events/index.ts
@@ -219,6 +219,11 @@ export class EventsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/events',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/events/instances/attachments/index.ts
+++ b/packages/graph/src/me/calendars/events/instances/attachments/index.ts
@@ -122,6 +122,11 @@ export class AttachmentsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/attachments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/events/instances/cancel.ts
+++ b/packages/graph/src/me/calendars/events/instances/cancel.ts
@@ -71,7 +71,7 @@ export class CancelClient {
   /**
    * `POST /me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/cancel`
    *
-   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting
+   * This action allows the organizer of a meeting to send a cancellation message and cancel the event.  The action moves the event to the Deleted Items folder. The organizer can also cancel an occurrence of a recurring meeting 
 by providing the occurrence event ID. An attendee calling this action gets an error (HTTP 400 Bad Request), with the following
 error message: &#x27;Your request can&#x27;t be completed. You need to be an organizer to cancel a meeting.&#x27; This action differs from Delete in that Cancel is available to only the organizer, and lets
 the organizer send a custom message to the attendees about the cancellation.

--- a/packages/graph/src/me/calendars/events/instances/extensions.ts
+++ b/packages/graph/src/me/calendars/events/instances/extensions.ts
@@ -112,6 +112,11 @@ export class ExtensionsClient {
     const url = getInjectedUrl(
       '/me/calendars/{calendar-id}/events/{event-id}/instances/{event-id1}/extensions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/events/instances/index.ts
+++ b/packages/graph/src/me/calendars/events/instances/index.ts
@@ -182,6 +182,11 @@ export class InstancesClient {
       [
         { name: 'startDateTime', in: 'query' },
         { name: 'endDateTime', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/calendars/index.ts
+++ b/packages/graph/src/me/calendars/index.ts
@@ -138,6 +138,11 @@ export class CalendarsClient {
     const url = getInjectedUrl(
       '/me/calendars',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/index.ts
+++ b/packages/graph/src/me/chats/index.ts
@@ -217,6 +217,11 @@ export class ChatsClient {
     const url = getInjectedUrl(
       '/me/chats',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/installedApps/index.ts
+++ b/packages/graph/src/me/chats/installedApps/index.ts
@@ -139,6 +139,11 @@ export class InstalledAppsClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/installedApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/members/index.ts
+++ b/packages/graph/src/me/chats/members/index.ts
@@ -129,6 +129,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/messages/hostedContents.ts
+++ b/packages/graph/src/me/chats/messages/hostedContents.ts
@@ -110,6 +110,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/messages/{chatMessage-id}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/messages/index.ts
+++ b/packages/graph/src/me/chats/messages/index.ts
@@ -169,6 +169,11 @@ export class MessagesClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/messages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/messages/replies/hostedContents.ts
+++ b/packages/graph/src/me/chats/messages/replies/hostedContents.ts
@@ -112,6 +112,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/messages/replies/index.ts
+++ b/packages/graph/src/me/chats/messages/replies/index.ts
@@ -160,6 +160,11 @@ export class RepliesClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/messages/{chatMessage-id}/replies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/permissionGrants.ts
+++ b/packages/graph/src/me/chats/permissionGrants.ts
@@ -109,6 +109,11 @@ export class PermissionGrantsClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/permissionGrants',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/pinnedMessages/index.ts
+++ b/packages/graph/src/me/chats/pinnedMessages/index.ts
@@ -119,6 +119,11 @@ export class PinnedMessagesClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/pinnedMessages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/chats/tabs/index.ts
+++ b/packages/graph/src/me/chats/tabs/index.ts
@@ -118,6 +118,11 @@ export class TabsClient {
     const url = getInjectedUrl(
       '/me/chats/{chat-id}/tabs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/me/photos.ts
+++ b/packages/graph/src/me/photos.ts
@@ -74,6 +74,11 @@ export class PhotosClient {
     const url = getInjectedUrl(
       '/me/photos',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/driveInclusionRules.ts
+++ b/packages/graph/src/solutions/backupRestore/driveInclusionRules.ts
@@ -104,6 +104,11 @@ export class DriveInclusionRulesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/driveInclusionRules',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/driveProtectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/driveProtectionUnits.ts
@@ -104,6 +104,11 @@ export class DriveProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/driveProtectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/exchangeProtectionPolicies/index.ts
+++ b/packages/graph/src/solutions/backupRestore/exchangeProtectionPolicies/index.ts
@@ -124,6 +124,11 @@ export class ExchangeProtectionPoliciesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/exchangeProtectionPolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/exchangeProtectionPolicies/mailboxInclusionRules.ts
+++ b/packages/graph/src/solutions/backupRestore/exchangeProtectionPolicies/mailboxInclusionRules.ts
@@ -81,6 +81,11 @@ export class MailboxInclusionRulesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxInclusionRules',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/exchangeProtectionPolicies/mailboxProtectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/exchangeProtectionPolicies/mailboxProtectionUnits.ts
@@ -81,6 +81,11 @@ export class MailboxProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/exchangeProtectionPolicies/{exchangeProtectionPolicy-id}/mailboxProtectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/exchangeRestoreSessions/granularMailboxRestoreArtifacts/index.ts
+++ b/packages/graph/src/solutions/backupRestore/exchangeRestoreSessions/granularMailboxRestoreArtifacts/index.ts
@@ -119,6 +119,11 @@ export class GranularMailboxRestoreArtifactsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/granularMailboxRestoreArtifacts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/exchangeRestoreSessions/index.ts
+++ b/packages/graph/src/solutions/backupRestore/exchangeRestoreSessions/index.ts
@@ -124,6 +124,11 @@ export class ExchangeRestoreSessionsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/exchangeRestoreSessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/exchangeRestoreSessions/mailboxRestoreArtifacts/index.ts
+++ b/packages/graph/src/solutions/backupRestore/exchangeRestoreSessions/mailboxRestoreArtifacts/index.ts
@@ -120,6 +120,11 @@ export class MailboxRestoreArtifactsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/exchangeRestoreSessions/{exchangeRestoreSession-id}/mailboxRestoreArtifacts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/mailboxInclusionRules.ts
+++ b/packages/graph/src/solutions/backupRestore/mailboxInclusionRules.ts
@@ -104,6 +104,11 @@ export class MailboxInclusionRulesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/mailboxInclusionRules',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/mailboxProtectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/mailboxProtectionUnits.ts
@@ -104,6 +104,11 @@ export class MailboxProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/mailboxProtectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/driveInclusionRules.ts
+++ b/packages/graph/src/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/driveInclusionRules.ts
@@ -81,6 +81,11 @@ export class DriveInclusionRulesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveInclusionRules',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/driveProtectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/driveProtectionUnits.ts
@@ -81,6 +81,11 @@ export class DriveProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/{oneDriveForBusinessProtectionPolicy-id}/driveProtectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/index.ts
+++ b/packages/graph/src/solutions/backupRestore/oneDriveForBusinessProtectionPolicies/index.ts
@@ -124,6 +124,11 @@ export class OneDriveForBusinessProtectionPoliciesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/oneDriveForBusinessProtectionPolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/oneDriveForBusinessRestoreSessions/driveRestoreArtifacts/index.ts
+++ b/packages/graph/src/solutions/backupRestore/oneDriveForBusinessRestoreSessions/driveRestoreArtifacts/index.ts
@@ -120,6 +120,11 @@ export class DriveRestoreArtifactsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/oneDriveForBusinessRestoreSessions/{oneDriveForBusinessRestoreSession-id}/driveRestoreArtifacts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/oneDriveForBusinessRestoreSessions/index.ts
+++ b/packages/graph/src/solutions/backupRestore/oneDriveForBusinessRestoreSessions/index.ts
@@ -114,6 +114,11 @@ export class OneDriveForBusinessRestoreSessionsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/oneDriveForBusinessRestoreSessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/protectionPolicies/index.ts
+++ b/packages/graph/src/solutions/backupRestore/protectionPolicies/index.ts
@@ -125,6 +125,11 @@ export class ProtectionPoliciesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/protectionPolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/protectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/protectionUnits.ts
@@ -77,6 +77,11 @@ export class ProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/protectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/restorePoints/index.ts
+++ b/packages/graph/src/solutions/backupRestore/restorePoints/index.ts
@@ -124,6 +124,11 @@ export class RestorePointsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/restorePoints',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/restoreSessions/index.ts
+++ b/packages/graph/src/solutions/backupRestore/restoreSessions/index.ts
@@ -115,6 +115,11 @@ export class RestoreSessionsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/restoreSessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/serviceApps/index.ts
+++ b/packages/graph/src/solutions/backupRestore/serviceApps/index.ts
@@ -125,6 +125,11 @@ export class ServiceAppsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/serviceApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/sharePointProtectionPolicies/index.ts
+++ b/packages/graph/src/solutions/backupRestore/sharePointProtectionPolicies/index.ts
@@ -124,6 +124,11 @@ export class SharePointProtectionPoliciesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/sharePointProtectionPolicies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/sharePointProtectionPolicies/siteInclusionRules.ts
+++ b/packages/graph/src/solutions/backupRestore/sharePointProtectionPolicies/siteInclusionRules.ts
@@ -81,6 +81,11 @@ export class SiteInclusionRulesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteInclusionRules',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/sharePointProtectionPolicies/siteProtectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/sharePointProtectionPolicies/siteProtectionUnits.ts
@@ -81,6 +81,11 @@ export class SiteProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/sharePointProtectionPolicies/{sharePointProtectionPolicy-id}/siteProtectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/sharePointRestoreSessions/index.ts
+++ b/packages/graph/src/solutions/backupRestore/sharePointRestoreSessions/index.ts
@@ -114,6 +114,11 @@ export class SharePointRestoreSessionsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/sharePointRestoreSessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/sharePointRestoreSessions/siteRestoreArtifacts/index.ts
+++ b/packages/graph/src/solutions/backupRestore/sharePointRestoreSessions/siteRestoreArtifacts/index.ts
@@ -120,6 +120,11 @@ export class SiteRestoreArtifactsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/sharePointRestoreSessions/{sharePointRestoreSession-id}/siteRestoreArtifacts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/siteInclusionRules.ts
+++ b/packages/graph/src/solutions/backupRestore/siteInclusionRules.ts
@@ -104,6 +104,11 @@ export class SiteInclusionRulesClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/siteInclusionRules',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/backupRestore/siteProtectionUnits.ts
+++ b/packages/graph/src/solutions/backupRestore/siteProtectionUnits.ts
@@ -104,6 +104,11 @@ export class SiteProtectionUnitsClient {
     const url = getInjectedUrl(
       '/solutions/backupRestore/siteProtectionUnits',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/appointments/index.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/appointments/index.ts
@@ -120,6 +120,11 @@ export class AppointmentsClient {
     const url = getInjectedUrl(
       '/solutions/bookingBusinesses/{bookingBusiness-id}/appointments',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/calendarView/index.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/calendarView/index.ts
@@ -121,6 +121,11 @@ export class CalendarViewClient {
       [
         { name: 'start', in: 'query' },
         { name: 'end', in: 'query' },
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/customQuestions.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/customQuestions.ts
@@ -110,6 +110,11 @@ export class CustomQuestionsClient {
     const url = getInjectedUrl(
       '/solutions/bookingBusinesses/{bookingBusiness-id}/customQuestions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/customers.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/customers.ts
@@ -110,6 +110,11 @@ export class CustomersClient {
     const url = getInjectedUrl(
       '/solutions/bookingBusinesses/{bookingBusiness-id}/customers',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/index.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/index.ts
@@ -195,6 +195,11 @@ export class BookingBusinessesClient {
     const url = getInjectedUrl(
       '/solutions/bookingBusinesses',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/services.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/services.ts
@@ -110,6 +110,11 @@ export class ServicesClient {
     const url = getInjectedUrl(
       '/solutions/bookingBusinesses/{bookingBusiness-id}/services',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingBusinesses/staffMembers.ts
+++ b/packages/graph/src/solutions/bookingBusinesses/staffMembers.ts
@@ -110,6 +110,11 @@ export class StaffMembersClient {
     const url = getInjectedUrl(
       '/solutions/bookingBusinesses/{bookingBusiness-id}/staffMembers',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/bookingCurrencies.ts
+++ b/packages/graph/src/solutions/bookingCurrencies.ts
@@ -104,6 +104,11 @@ export class BookingCurrenciesClient {
     const url = getInjectedUrl(
       '/solutions/bookingCurrencies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/events/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/events/index.ts
@@ -153,6 +153,11 @@ export class EventsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/events',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/events/presenters.ts
+++ b/packages/graph/src/solutions/virtualEvents/events/presenters.ts
@@ -109,6 +109,11 @@ export class PresentersClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/events/{virtualEvent-id}/presenters',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/events/sessions/attendanceReports/attendanceRecords.ts
+++ b/packages/graph/src/solutions/virtualEvents/events/sessions/attendanceReports/attendanceRecords.ts
@@ -112,6 +112,11 @@ export class AttendanceRecordsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/events/sessions/attendanceReports/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/events/sessions/attendanceReports/index.ts
@@ -121,6 +121,11 @@ export class AttendanceReportsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/events/{virtualEvent-id}/sessions/{virtualEventSession-id}/attendanceReports',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/events/sessions/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/events/sessions/index.ts
@@ -119,6 +119,11 @@ export class SessionsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/events/{virtualEvent-id}/sessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/townhalls/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/townhalls/index.ts
@@ -124,6 +124,11 @@ export class TownhallsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/townhalls',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/townhalls/presenters.ts
+++ b/packages/graph/src/solutions/virtualEvents/townhalls/presenters.ts
@@ -114,6 +114,11 @@ export class PresentersClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },
@@ -136,7 +141,7 @@ export class PresentersClient {
   /**
    * `GET /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters/{virtualEventPresenter-id}`
    *
-   * Read the properties and relationships of a virtualEventPresenter object. Currently the supported virtual event types are:
+   * Read the properties and relationships of a virtualEventPresenter object. Currently the supported virtual event types are: 
 - virtualEventTownhall
 - virtualEventWebinar
    */
@@ -198,7 +203,7 @@ export class PresentersClient {
   /**
    * `POST /solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/presenters`
    *
-   * Create a new virtualEventPresenter object on a virtual event. Currently, the following types of virtual events are supported:
+   * Create a new virtualEventPresenter object on a virtual event. Currently, the following types of virtual events are supported: 
 - virtualEventTownhall
 - virtualEventWebinar
    */

--- a/packages/graph/src/solutions/virtualEvents/townhalls/sessions/attendanceReports/attendanceRecords.ts
+++ b/packages/graph/src/solutions/virtualEvents/townhalls/sessions/attendanceReports/attendanceRecords.ts
@@ -112,6 +112,11 @@ export class AttendanceRecordsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/townhalls/sessions/attendanceReports/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/townhalls/sessions/attendanceReports/index.ts
@@ -121,6 +121,11 @@ export class AttendanceReportsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions/{virtualEventSession-id}/attendanceReports',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/townhalls/sessions/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/townhalls/sessions/index.ts
@@ -119,6 +119,11 @@ export class SessionsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/townhalls/{virtualEventTownhall-id}/sessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/index.ts
@@ -144,6 +144,11 @@ export class WebinarsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/presenters.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/presenters.ts
@@ -109,6 +109,11 @@ export class PresentersClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },
@@ -193,7 +198,7 @@ export class PresentersClient {
   /**
    * `POST /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/presenters`
    *
-   * Create a new virtualEventPresenter object on a virtual event. Currently, the following types of virtual events are supported:
+   * Create a new virtualEventPresenter object on a virtual event. Currently, the following types of virtual events are supported: 
 - virtualEventTownhall
 - virtualEventWebinar
    */

--- a/packages/graph/src/solutions/virtualEvents/webinars/registrationConfiguration/questions.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/registrationConfiguration/questions.ts
@@ -107,6 +107,11 @@ export class QuestionsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrationConfiguration/questions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/registrations/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/registrations/index.ts
@@ -129,6 +129,11 @@ export class RegistrationsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/registrations/sessions.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/registrations/sessions.ts
@@ -81,6 +81,11 @@ export class SessionsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/registrations/{virtualEventRegistration-id}/sessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/sessions/attendanceReports/attendanceRecords.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/sessions/attendanceReports/attendanceRecords.ts
@@ -112,6 +112,11 @@ export class AttendanceRecordsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/sessions/attendanceReports/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/sessions/attendanceReports/index.ts
@@ -121,6 +121,11 @@ export class AttendanceReportsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}/attendanceReports',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/solutions/virtualEvents/webinars/sessions/index.ts
+++ b/packages/graph/src/solutions/virtualEvents/webinars/sessions/index.ts
@@ -110,7 +110,7 @@ export class SessionsClient {
   /**
    * `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions`
    *
-   * Get a list of all virtualEventSession summary objects under a virtual event. A session summary contains only the endDateTime, id, joinWebUrl, startDateTime, and subject of a virtual event session. The rest of session properties will be null. Currently, the following virtual event types are supported:
+   * Get a list of all virtualEventSession summary objects under a virtual event. A session summary contains only the endDateTime, id, joinWebUrl, startDateTime, and subject of a virtual event session. The rest of session properties will be null. Currently, the following virtual event types are supported: 
 - virtualEventTownhall
 - virtualEventWebinar
    */
@@ -121,6 +121,11 @@ export class SessionsClient {
     const url = getInjectedUrl(
       '/solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },
@@ -143,7 +148,7 @@ export class SessionsClient {
   /**
    * `GET /solutions/virtualEvents/webinars/{virtualEventWebinar-id}/sessions/{virtualEventSession-id}`
    *
-   * Read the properties and relationships of a virtualEventSession object.  Currently, the following virtual event types are supported:
+   * Read the properties and relationships of a virtualEventSession object.  Currently, the following virtual event types are supported: 
 - virtualEventTownhall
 - virtualEventWebinar
    */

--- a/packages/graph/src/teams/allChannels.ts
+++ b/packages/graph/src/teams/allChannels.ts
@@ -80,6 +80,11 @@ export class AllChannelsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/allChannels',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/archive.ts
+++ b/packages/graph/src/teams/archive.ts
@@ -71,7 +71,7 @@ export class ArchiveClient {
   /**
    * `POST /teams/{team-id}/archive`
    *
-   * Archive the specified team.
+   * Archive the specified team. 
 When a team is archived, users can no longer make most changes to the team. For example, users can no longer: send or like messages on any channel in the team; edit the team&#x27;s name or description; nor edit other settings. However, membership changes to the team are still allowed. Archiving is an async operation. A team is archived once the async operation completes successfully, which might occur subsequent to a response from this API. To archive a team, the team and group must have an owner. To restore a team from its archived state, use the API to unarchive.
    */
   async create(

--- a/packages/graph/src/teams/channels/index.ts
+++ b/packages/graph/src/teams/channels/index.ts
@@ -209,6 +209,11 @@ export class ChannelsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/members/index.ts
+++ b/packages/graph/src/teams/channels/members/index.ts
@@ -131,6 +131,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/messages/hostedContents.ts
+++ b/packages/graph/src/teams/channels/messages/hostedContents.ts
@@ -112,6 +112,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/messages/index.ts
+++ b/packages/graph/src/teams/channels/messages/index.ts
@@ -170,6 +170,11 @@ export class MessagesClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/messages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },
@@ -225,7 +230,7 @@ export class MessagesClient {
   /**
    * `PATCH /teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}`
    *
-   * Update a chatMessage object.
+   * Update a chatMessage object. 
 Except for the policyViolation property, all properties of a chatMessage can be updated in delegated permissions scenarios.
 Only the policyViolation property of a chatMessage can be updated in application permissions scenarios. The update only works for chats where members are Microsoft Teams users. If one of the participants is using Skype, the operation fails. This method doesn&#x27;t support federation. Only the user in the tenant who sent the message can perform data loss prevention (DLP) updates on the specified chat message.
    */

--- a/packages/graph/src/teams/channels/messages/replies/hostedContents.ts
+++ b/packages/graph/src/teams/channels/messages/replies/hostedContents.ts
@@ -113,6 +113,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/messages/replies/index.ts
+++ b/packages/graph/src/teams/channels/messages/replies/index.ts
@@ -161,6 +161,11 @@ export class RepliesClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/messages/{chatMessage-id}/replies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/sharedWithTeams/allowedMembers.ts
+++ b/packages/graph/src/teams/channels/sharedWithTeams/allowedMembers.ts
@@ -83,6 +83,11 @@ export class AllowedMembersClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/sharedWithTeams/index.ts
+++ b/packages/graph/src/teams/channels/sharedWithTeams/index.ts
@@ -131,6 +131,11 @@ export class SharedWithTeamsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/sharedWithTeams',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/channels/tabs/index.ts
+++ b/packages/graph/src/teams/channels/tabs/index.ts
@@ -121,6 +121,11 @@ export class TabsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/channels/{channel-id}/tabs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/clone.ts
+++ b/packages/graph/src/teams/clone.ts
@@ -72,7 +72,7 @@ export class CloneClient {
    * `POST /teams/{team-id}/clone`
    *
    * Create a copy of a team. This operation also creates a copy of the corresponding group.
-You can specify which parts of the team to clone: When tabs are cloned, they aren&#x27;t configured. The tabs are displayed on the tab bar in Microsoft Teams, and the first time a user opens them, they must go through the configuration screen.
+You can specify which parts of the team to clone: When tabs are cloned, they aren&#x27;t configured. The tabs are displayed on the tab bar in Microsoft Teams, and the first time a user opens them, they must go through the configuration screen. 
 If the user who opens the tab doesn&#x27;t have permission to configure apps, they see a message that says that the tab isn&#x27;t configured. Cloning is a long-running operation. After the POST clone returns, you need to GET the operation returned by the Location: header to see if it&#x27;s running, succeeded, or failed. You should continue to GET until the status isn&#x27;t running. The recommended delay between GETs is 5 seconds.
    */
   async create(

--- a/packages/graph/src/teams/group/serviceProvisioningErrors.ts
+++ b/packages/graph/src/teams/group/serviceProvisioningErrors.ts
@@ -76,6 +76,11 @@ export class ServiceProvisioningErrorsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/group/serviceProvisioningErrors',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/incomingChannels.ts
+++ b/packages/graph/src/teams/incomingChannels.ts
@@ -80,6 +80,11 @@ export class IncomingChannelsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/incomingChannels',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/index.ts
+++ b/packages/graph/src/teams/index.ts
@@ -278,6 +278,11 @@ export class TeamsClient {
     const url = getInjectedUrl(
       '/teams',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/installedApps/index.ts
+++ b/packages/graph/src/teams/installedApps/index.ts
@@ -140,6 +140,11 @@ export class InstalledAppsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/installedApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/members/index.ts
+++ b/packages/graph/src/teams/members/index.ts
@@ -130,6 +130,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/operations.ts
+++ b/packages/graph/src/teams/operations.ts
@@ -109,6 +109,11 @@ export class OperationsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/operations',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/permissionGrants.ts
+++ b/packages/graph/src/teams/permissionGrants.ts
@@ -109,6 +109,11 @@ export class PermissionGrantsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/permissionGrants',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/members/index.ts
+++ b/packages/graph/src/teams/primaryChannel/members/index.ts
@@ -125,6 +125,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/messages/hostedContents.ts
+++ b/packages/graph/src/teams/primaryChannel/messages/hostedContents.ts
@@ -110,6 +110,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/messages/index.ts
+++ b/packages/graph/src/teams/primaryChannel/messages/index.ts
@@ -165,6 +165,11 @@ export class MessagesClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/messages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/messages/replies/hostedContents.ts
+++ b/packages/graph/src/teams/primaryChannel/messages/replies/hostedContents.ts
@@ -112,6 +112,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/messages/replies/index.ts
+++ b/packages/graph/src/teams/primaryChannel/messages/replies/index.ts
@@ -160,6 +160,11 @@ export class RepliesClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/messages/{chatMessage-id}/replies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/sharedWithTeams/allowedMembers.ts
+++ b/packages/graph/src/teams/primaryChannel/sharedWithTeams/allowedMembers.ts
@@ -81,6 +81,11 @@ export class AllowedMembersClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/sharedWithTeams/index.ts
+++ b/packages/graph/src/teams/primaryChannel/sharedWithTeams/index.ts
@@ -125,6 +125,11 @@ export class SharedWithTeamsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/sharedWithTeams',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/primaryChannel/tabs/index.ts
+++ b/packages/graph/src/teams/primaryChannel/tabs/index.ts
@@ -115,6 +115,11 @@ export class TabsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/primaryChannel/tabs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/offerShiftRequests.ts
+++ b/packages/graph/src/teams/schedule/offerShiftRequests.ts
@@ -105,6 +105,11 @@ export class OfferShiftRequestsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/offerShiftRequests',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/openShiftChangeRequests.ts
+++ b/packages/graph/src/teams/schedule/openShiftChangeRequests.ts
@@ -105,6 +105,11 @@ export class OpenShiftChangeRequestsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/openShiftChangeRequests',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/openShifts.ts
+++ b/packages/graph/src/teams/schedule/openShifts.ts
@@ -106,6 +106,11 @@ export class OpenShiftsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/openShifts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/schedulingGroups.ts
+++ b/packages/graph/src/teams/schedule/schedulingGroups.ts
@@ -107,6 +107,11 @@ This method does not remove the schedulingGroup from the schedule. Existing shif
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/schedulingGroups',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/shifts.ts
+++ b/packages/graph/src/teams/schedule/shifts.ts
@@ -106,6 +106,11 @@ export class ShiftsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/shifts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/swapShiftsChangeRequests.ts
+++ b/packages/graph/src/teams/schedule/swapShiftsChangeRequests.ts
@@ -105,6 +105,11 @@ export class SwapShiftsChangeRequestsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/swapShiftsChangeRequests',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/timeOffReasons.ts
+++ b/packages/graph/src/teams/schedule/timeOffReasons.ts
@@ -106,6 +106,11 @@ export class TimeOffReasonsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/timeOffReasons',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/timeOffRequests.ts
+++ b/packages/graph/src/teams/schedule/timeOffRequests.ts
@@ -106,6 +106,11 @@ export class TimeOffRequestsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/timeOffRequests',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/schedule/timesOff.ts
+++ b/packages/graph/src/teams/schedule/timesOff.ts
@@ -106,6 +106,11 @@ export class TimesOffClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/schedule/timesOff',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/tags/index.ts
+++ b/packages/graph/src/teams/tags/index.ts
@@ -119,6 +119,11 @@ export class TagsClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/tags',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teams/tags/members.ts
+++ b/packages/graph/src/teams/tags/members.ts
@@ -111,6 +111,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/teams/{team-id}/tags/{teamworkTag-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamsTemplates.ts
+++ b/packages/graph/src/teamsTemplates.ts
@@ -99,6 +99,11 @@ export class TeamsTemplatesClient {
     const url = getInjectedUrl(
       '/teamsTemplates',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedChats/index.ts
+++ b/packages/graph/src/teamwork/deletedChats/index.ts
@@ -113,6 +113,11 @@ export class DeletedChatsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedChats',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/index.ts
@@ -209,6 +209,11 @@ export class ChannelsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/members/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/members/index.ts
@@ -130,6 +130,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/messages/hostedContents.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/messages/hostedContents.ts
@@ -112,6 +112,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/messages/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/messages/index.ts
@@ -170,6 +170,11 @@ export class MessagesClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/messages/replies/hostedContents.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/messages/replies/hostedContents.ts
@@ -113,6 +113,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/messages/replies/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/messages/replies/index.ts
@@ -162,6 +162,11 @@ export class RepliesClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/messages/{chatMessage-id}/replies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/sharedWithTeams/allowedMembers.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/sharedWithTeams/allowedMembers.ts
@@ -81,6 +81,11 @@ export class AllowedMembersClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams/{sharedWithChannelTeamInfo-id}/allowedMembers',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/sharedWithTeams/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/sharedWithTeams/index.ts
@@ -131,6 +131,11 @@ export class SharedWithTeamsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/sharedWithTeams',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/channels/tabs/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/channels/tabs/index.ts
@@ -120,6 +120,11 @@ export class TabsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams/{deletedTeam-id}/channels/{channel-id}/tabs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/deletedTeams/index.ts
+++ b/packages/graph/src/teamwork/deletedTeams/index.ts
@@ -113,6 +113,11 @@ export class DeletedTeamsClient {
     const url = getInjectedUrl(
       '/teamwork/deletedTeams',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/teamwork/workforceIntegrations.ts
+++ b/packages/graph/src/teamwork/workforceIntegrations.ts
@@ -105,6 +105,11 @@ export class WorkforceIntegrationsClient {
     const url = getInjectedUrl(
       '/teamwork/workforceIntegrations',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/index.ts
+++ b/packages/graph/src/users/chats/index.ts
@@ -226,6 +226,11 @@ export class ChatsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/installedApps/index.ts
+++ b/packages/graph/src/users/chats/installedApps/index.ts
@@ -140,6 +140,11 @@ export class InstalledAppsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/installedApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/members/index.ts
+++ b/packages/graph/src/users/chats/members/index.ts
@@ -130,6 +130,11 @@ export class MembersClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/members',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/messages/hostedContents.ts
+++ b/packages/graph/src/users/chats/messages/hostedContents.ts
@@ -111,6 +111,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/messages/index.ts
+++ b/packages/graph/src/users/chats/messages/index.ts
@@ -170,6 +170,11 @@ export class MessagesClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/messages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/messages/replies/hostedContents.ts
+++ b/packages/graph/src/users/chats/messages/replies/hostedContents.ts
@@ -113,6 +113,11 @@ export class HostedContentsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies/{chatMessage-id1}/hostedContents',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/messages/replies/index.ts
+++ b/packages/graph/src/users/chats/messages/replies/index.ts
@@ -161,6 +161,11 @@ export class RepliesClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/messages/{chatMessage-id}/replies',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/permissionGrants.ts
+++ b/packages/graph/src/users/chats/permissionGrants.ts
@@ -110,6 +110,11 @@ export class PermissionGrantsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/permissionGrants',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/pinnedMessages/index.ts
+++ b/packages/graph/src/users/chats/pinnedMessages/index.ts
@@ -120,6 +120,11 @@ export class PinnedMessagesClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/pinnedMessages',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/chats/tabs/index.ts
+++ b/packages/graph/src/users/chats/tabs/index.ts
@@ -120,6 +120,11 @@ export class TabsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/chats/{chat-id}/tabs',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/index.ts
+++ b/packages/graph/src/users/index.ts
@@ -140,6 +140,10 @@ export class UsersClient {
       '/users',
       [
         { name: 'ConsistencyLevel', in: 'header' },
+        { name: '$top', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/onlineMeetings/attendanceReports/attendanceRecords.ts
+++ b/packages/graph/src/users/onlineMeetings/attendanceReports/attendanceRecords.ts
@@ -112,6 +112,11 @@ export class AttendanceRecordsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/onlineMeetings/attendanceReports/index.ts
+++ b/packages/graph/src/users/onlineMeetings/attendanceReports/index.ts
@@ -120,6 +120,11 @@ export class AttendanceReportsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/onlineMeetings/index.ts
+++ b/packages/graph/src/users/onlineMeetings/index.ts
@@ -179,6 +179,11 @@ export class OnlineMeetingsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/onlineMeetings',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/onlineMeetings/recordings/index.ts
+++ b/packages/graph/src/users/onlineMeetings/recordings/index.ts
@@ -120,6 +120,11 @@ export class RecordingsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/onlineMeetings/{onlineMeeting-id}/recordings',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/onlineMeetings/transcripts/index.ts
+++ b/packages/graph/src/users/onlineMeetings/transcripts/index.ts
@@ -130,6 +130,11 @@ export class TranscriptsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/onlineMeetings/{onlineMeeting-id}/transcripts',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/teamwork/associatedTeams/index.ts
+++ b/packages/graph/src/users/teamwork/associatedTeams/index.ts
@@ -115,6 +115,11 @@ export class AssociatedTeamsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/teamwork/associatedTeams',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },

--- a/packages/graph/src/users/teamwork/installedApps/index.ts
+++ b/packages/graph/src/users/teamwork/installedApps/index.ts
@@ -136,6 +136,11 @@ export class InstalledAppsClient {
     const url = getInjectedUrl(
       '/users/{user-id}/teamwork/installedApps',
       [
+        { name: '$top', in: 'query' },
+        { name: '$skip', in: 'query' },
+        { name: '$search', in: 'query' },
+        { name: '$filter', in: 'query' },
+        { name: '$count', in: 'query' },
         { name: '$orderby', in: 'query' },
         { name: '$select', in: 'query' },
         { name: '$expand', in: 'query' },


### PR DESCRIPTION
Fixes #98 

Our graphql generator script was ignoring ref parameters (even though the types were correct). This PR fixes it.

Steps:
1. Client now has a concept of a top-level components object
2. This components object is shared with all the children so it's passed down to all the clients.
3. When resolving parameter names, we check if `$ref` is in the name. if it is, we look it up in the components. 
4. Interestingly, the component names in $ref are usually "top", but the component.parameter.name is `$top`.