### PR TITLE
Fix system prompt sending, and add comment

### DIFF
--- a/packages/ai/src/prompts/chat.ts
+++ b/packages/ai/src/prompts/chat.ts
@@ -25,7 +25,9 @@ export type ChatPromptOptions<TOptions extends Record<string, any> = Record<stri
 
   /**
    * the defining characteristics/objective
-   * of the prompt
+   * of the prompt. This is commonly used to provide a system prompt.
+   * If you supply the system prompt as part of the messages,
+   * you do not need to supply this option.
    */
   readonly instructions?: string | string[] | ITemplate;
 

--- a/packages/openai/src/chat.ts
+++ b/packages/openai/src/chat.ts
@@ -131,7 +131,7 @@ export class OpenAIChatModel implements IChatModel<ChatCompletionCreateParams> {
       const completion = await this._openai.chat.completions.create({
         ...this.options.requestOptions,
         ...options.request,
-        model: this.options.model,
+        model: 'endpoint' in this.options ? '' : this.options.model,
         stream: !!options.onChunk,
         tools:
           Object.keys(options.functions || {}).length === 0

--- a/packages/openai/src/chat.ts
+++ b/packages/openai/src/chat.ts
@@ -1,9 +1,9 @@
 import {
-  IChatModel,
   ChatSendOptions,
+  IChatModel,
   LocalMemory,
-  ModelMessage,
   Message,
+  ModelMessage,
 } from '@microsoft/spark.ai';
 import { ConsoleLogger, ILogger } from '@microsoft/spark.common/logging';
 
@@ -60,10 +60,10 @@ export class OpenAIChatModel implements IChatModel<ChatCompletionCreateParams> {
         ? new AzureOpenAI({
             apiKey: options.apiKey,
             apiVersion: options.apiVersion,
-            endpoint: options.endpoint,
+            endpoint: options.endpoint?.replace(/\/$/, ''),
             deployment: options.model,
             azureADTokenProvider: options.azureADTokenProvider,
-            baseURL: options.baseUrl,
+            baseURL: options.baseUrl?.replace(/\/$/, ''),
             organization: options.organization,
             project: options.project,
             defaultHeaders: options.headers,
@@ -72,7 +72,7 @@ export class OpenAIChatModel implements IChatModel<ChatCompletionCreateParams> {
           })
         : new OpenAI({
             apiKey: options.apiKey,
-            baseURL: options.baseUrl,
+            baseURL: options.baseUrl?.replace(/\/$/, ''),
             organization: options.organization,
             project: options.project,
             defaultHeaders: options.headers,
@@ -124,14 +124,14 @@ export class OpenAIChatModel implements IChatModel<ChatCompletionCreateParams> {
     const messages = await memory.values();
 
     if (options.system) {
-      messages.push(options.system);
+      messages.unshift(options.system);
     }
 
     try {
       const completion = await this._openai.chat.completions.create({
         ...this.options.requestOptions,
         ...options.request,
-        model: 'endpoint' in this.options ? '' : this.options.model,
+        model: this.options.model,
         stream: !!options.onChunk,
         tools:
           Object.keys(options.functions || {}).length === 0


### PR DESCRIPTION
- System prompts right now were being `push`ed after the messages. We want them to be at the top of the messages array.
- Remove trailing slashes from API urls if they exist.
- Added a comment that makes it more clear the `instructions` are commonly referred to as system prompts. 