### PR TITLE
[Client] Use MSAL to generate NAA token and pass in authorization header when making function calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -502,21 +502,21 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.5.1.tgz",
-      "integrity": "sha512-vcva6qA4ytVjg52Ew+RxXGKRuoDMdvNOwT+kECNC36kujYalFQe9B5SNud4WVa/Zk12KFa0bkOHFnjP8cgDv3A==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.9.1.tgz",
+      "integrity": "sha512-GTKj/2xvgD918xULWRwoJ3kiCCZNzeopxa/nDfMC4o6KzrnuWbT3K1AtIFUxok9yC6VrUOgIZXMygky06xDA1g==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.2.0"
+        "@azure/msal-common": "15.4.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-browser/node_modules/@azure/msal-common": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.2.0.tgz",
-      "integrity": "sha512-HiYfGAKthisUYqHG1nImCf/uzcyS31wng3o+CycWLIM9chnYJ9Lk6jZ30Y6YiYYpTQ9+z/FGUpiKKekd3Arc0A==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.4.0.tgz",
+      "integrity": "sha512-reeIUDXt6Xc+FpCBDEbUFQWvJ6SjE0JwsGYIfa3ZCR6Tpzjc9J1v+/InQgfCeJzfTRd7PDJVxI6TSzOmOd7+Ag==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -4639,6 +4639,17 @@
     "node_modules/@microsoft/spark.openai": {
       "resolved": "packages/openai",
       "link": true
+    },
+    "node_modules/@microsoft/teams-js": {
+      "version": "2.35.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-2.35.0.tgz",
+      "integrity": "sha512-TVsfjJofxSvM0e/SR9k4IMHSGrkLzR7kVEAkvmzb4dmkB/BUNcFFlMKUdzAY2TLx6+rjkILEnDW9V+yU7EbZIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "debug": "^4.3.3"
+      }
     },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.6.0",
@@ -20940,6 +20951,7 @@
       "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
+        "@azure/msal-browser": "^4.9.1",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -20953,7 +20965,8 @@
       },
       "peerDependencies": {
         "@microsoft/spark.api": "*",
-        "@microsoft/spark.common": "*"
+        "@microsoft/spark.common": "*",
+        "@microsoft/teams-js": "^2.35.0"
       }
     },
     "packages/client/node_modules/glob": {

--- a/packages/apps/src/contexts/client.ts
+++ b/packages/apps/src/contexts/client.ts
@@ -56,4 +56,8 @@ export interface IClientContext {
    * such as scrolling to or activating a specific piece of content.
    */
   readonly subPageId?: string;
+  /**
+   * The MSAL entra token.
+   */
+  readonly authToken?: string;
 }

--- a/packages/cli/configs/ttk/embed/teamsapp.local.yml.hbs
+++ b/packages/cli/configs/ttk/embed/teamsapp.local.yml.hbs
@@ -98,3 +98,4 @@ deploy:
           PORT: 3978
           CLIENT_ID: $\{{BOT_ID}}
           CLIENT_SECRET: $\{{SECRET_BOT_PASSWORD}}
+          TENANT_ID: $\{{AAD_APP_TENANT_ID}}

--- a/packages/cli/src/project/attributes/ttk.ts
+++ b/packages/cli/src/project/attributes/ttk.ts
@@ -60,6 +60,12 @@ export class TeamsToolkitAttribute implements IProjectAttribute {
             'teamsapp.local.yml',
             'deploy.1.with.envs.VITE_CLIENT_SECRET',
             '${{SECRET_BOT_PASSWORD}}'
+          ),
+          new FileYamlSet(
+            targetDir,
+            'teamsapp.local.yml',
+            'deploy.1.with.envs.VITE_TENANT_ID',
+            '${{AAD_APP_TENANT_ID}}'
           )
         )
       )

--- a/packages/cli/templates/typescript/tab/src/Tab/App.tsx
+++ b/packages/cli/templates/typescript/tab/src/Tab/App.tsx
@@ -5,29 +5,28 @@ import { ConsoleLogger } from '@microsoft/spark.common';
 import './App.css';
 
 export default function App() {
-  const [context, setContext] = React.useState<client.Context>();
+  const [greeting, setGreeting] = React.useState('');
 
   React.useEffect(() => {
     (async () => {
-      const app = new client.App({
-        clientId: import.meta.env.VITE_CLIENT_ID,
-        clientSecret: import.meta.env.VITE_CLIENT_SECRET,
-        tenantId: import.meta.env.VITE_TENANT_ID,
+      const clientId = import.meta.env.VITE_CLIENT_ID;
+      const tenantId = import.meta.env.VITE_TENANT_ID;
+      const app = new client.App(clientId, {
+        tenantId,
         logger: new ConsoleLogger('@samples/tab', { level: 'debug' }),
       });
 
-      const context = await app.connect();
-      setContext(context);
+      await app.start();
 
-      const res = await app.exec('hello-world', { hello: 'world' });
-      app.log.info(res);
+      const result = await app.exec<string>('hello-world');
+      setGreeting(result);
     })();
   }, []);
 
   return (
     <div className="App">
       <pre>
-        <code>{JSON.stringify(context, null, 2)}</code>
+        <code>{greeting}</code>
       </pre>
     </div>
   );

--- a/packages/cli/templates/typescript/tab/src/index.ts
+++ b/packages/cli/templates/typescript/tab/src/index.ts
@@ -10,6 +10,7 @@ const app = new App({
 app.tab('test', path.resolve('dist/client'));
 app.function('hello-world', async ({ log, data }) => {
   log.info(data);
+  return 'Hello, world!';
 });
 
 (async () => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,11 +34,13 @@
     "test": "npx jest"
   },
   "dependencies": {
+    "@azure/msal-browser": "^4.9.1",
     "uuid": "^11.0.5"
   },
   "peerDependencies": {
     "@microsoft/spark.api": "*",
-    "@microsoft/spark.common": "*"
+    "@microsoft/spark.common": "*",
+    "@microsoft/teams-js": "^2.35.0"
   },
   "devDependencies": {
     "@microsoft/spark.config": "*",

--- a/packages/client/src/app.spec.ts
+++ b/packages/client/src/app.spec.ts
@@ -1,0 +1,335 @@
+const teamsJsInitializeMock = jest.fn();
+const msalCreateNPCAppMock = jest.fn();
+const msalInitializeMock = jest.fn();
+const httpClientPostMock = jest.fn();
+
+import * as MsalUtils from './msalUtils';
+import { App } from './app';
+
+jest.mock('@microsoft/teams-js', () => {
+  return {
+    ...jest.requireActual('@microsoft/teams-js'),
+    app: {
+      initialize: teamsJsInitializeMock.mockResolvedValue(undefined),
+      getContext: jest.fn(() => {
+        return Promise.resolve({
+          user: {
+            id: 'mock-user-id',
+            displayName: 'Mock User',
+            email: '',
+            upn: 'mock-upn',
+            tenant: { id: 'mock-tenant-id' },
+          },
+          team: {
+            id: 'mock-team-id',
+            name: 'Mock Team',
+          },
+          channel: {
+            id: 'mock-channel-id',
+            name: 'Mock Channel',
+          },
+          chat: {
+            id: 'mock-chat-id',
+            name: 'Mock Chat',
+          },
+          meeting: {
+            id: 'mock-meeting-id',
+            subject: 'Mock Meeting',
+          },
+          subPageId: 'mock-sub-page-id',
+          app: {
+            appId: {
+              toString: () => 'mock-app-id',
+            },
+            sessionId: 'mock-session-id',
+            parentMessageId: 'mock-parent-message-id',
+          },
+          page: {
+            id: 'mock-page-id',
+            subPageId: 'mock-sub-page-id',
+          },
+        });
+      }),
+    },
+  };
+});
+
+jest.mock('@azure/msal-browser', () => {
+  return {
+    ...jest.requireActual('@azure/msal-browser'),
+    createNestablePublicClientApplication: msalCreateNPCAppMock.mockResolvedValue({
+      initialize: msalInitializeMock,
+    }),
+  };
+});
+
+jest.mock('@microsoft/spark.common/http', () => {
+  return {
+    ...jest.requireActual('@microsoft/spark.common/http'),
+    Client: jest.fn().mockImplementation(() => {
+      return {
+        post: httpClientPostMock,
+      };
+    }),
+  };
+});
+
+const mockLogger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  log: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+const mockClientId = 'mock-client-id';
+const mockAppTenantId = 'mock-app-tenant-id';
+const mockDate = new Date('2025-10-01T00:00:00Z');
+const mockAccessToken = 'eyJ0MockAccessTokenKmydpg';
+
+describe('App', () => {
+  let acquireMsalAccessTokenSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    acquireMsalAccessTokenSpy = jest
+      .spyOn(MsalUtils, 'acquireMsalAccessToken')
+      .mockResolvedValue(mockAccessToken);
+    jest.useFakeTimers().setSystemTime(mockDate);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('constructor', () => {
+    it('supports default options', () => {
+      const app = new App(mockClientId);
+      expect(app.options).toEqual({
+        baseUrl: undefined,
+        logger: undefined,
+        msalOptions: undefined,
+      });
+      expect(app.clientId).toEqual(mockClientId);
+      expect(app.startedAt).toBeUndefined();
+      expect(app.msalInstance).toBeUndefined();
+      expect(app.log).toBeInstanceOf(Object);
+      expect(app.log).not.toEqual(mockLogger);
+    });
+
+    it('supports custom options', () => {
+      const customOptions = {
+        tenantId: mockAppTenantId,
+        baseUrl: 'https://example.com',
+        logger: mockLogger,
+        msalOptions: {
+          configuration: { auth: { clientId: mockClientId } },
+          defaultSilentRequest: { scopes: ['User.ReadWrite'] },
+        },
+      };
+      const app = new App(mockClientId, customOptions);
+      expect(app.options).toEqual(customOptions);
+      expect(app.startedAt).toBeUndefined();
+      expect(app.msalInstance).toBeUndefined();
+      expect(app.log).toEqual(mockLogger);
+    });
+
+    it('throws if client ID is invalid', () => {
+      expect(() => new App('')).toThrow('Invalid client ID.');
+    });
+  });
+
+  describe('start', () => {
+    it('should initialize teams-js and msal with default values', async () => {
+      const app = new App(mockClientId);
+      await app.start();
+
+      expect(teamsJsInitializeMock).toHaveBeenCalledTimes(1);
+      expect(teamsJsInitializeMock).toHaveBeenCalledWith();
+      expect(msalCreateNPCAppMock).toHaveBeenCalledTimes(1);
+      expect(msalCreateNPCAppMock).toHaveBeenCalledWith({
+        auth: {
+          authority: '',
+          clientId: 'mock-client-id',
+          postLogoutRedirectUri: '/',
+          redirectUri: '/',
+        },
+        system: {
+          loggerOptions: {
+            loggerCallback: expect.any(Function),
+            piiLoggingEnabled: false,
+          },
+        },
+      });
+      expect(msalInitializeMock).toHaveBeenCalledTimes(1);
+      expect(app.startedAt).toEqual(mockDate);
+      expect(app.msalInstance).toBeDefined();
+    });
+
+    it('can initialize teams-js and msal with custom MSAL configuration', async () => {
+      const msalConfig = {
+        auth: {
+          clientId: 'custom-client-id',
+        },
+      };
+      const app = new App(mockClientId, { msalOptions: { configuration: msalConfig } });
+      await app.start();
+
+      expect(teamsJsInitializeMock).toHaveBeenCalledTimes(1);
+      expect(teamsJsInitializeMock).toHaveBeenCalledWith();
+      expect(msalCreateNPCAppMock).toHaveBeenCalledTimes(1);
+      expect(msalCreateNPCAppMock).toHaveBeenCalledWith(msalConfig);
+      expect(msalInitializeMock).toHaveBeenCalledTimes(1);
+      expect(app.startedAt).toEqual(mockDate);
+      expect(app.msalInstance).toBeDefined();
+    });
+
+    it('is safe to call when already started', async () => {
+      const app = new App(mockClientId, { logger: mockLogger });
+      await app.start();
+
+      expect(teamsJsInitializeMock).toHaveBeenCalledTimes(1);
+      expect(msalCreateNPCAppMock).toHaveBeenCalledTimes(1);
+      expect(app.startedAt).toEqual(mockDate);
+      expect(app.msalInstance).toBeDefined();
+
+      jest.setSystemTime(mockDate.getTime() + 1000);
+      await app.start();
+
+      expect(mockLogger.debug).toHaveBeenLastCalledWith('app already started');
+      expect(teamsJsInitializeMock).toHaveBeenCalledTimes(1);
+      expect(msalCreateNPCAppMock).toHaveBeenCalledTimes(1);
+      expect(app.startedAt).toEqual(mockDate);
+      expect(app.msalInstance).toBeDefined();
+    });
+
+    it('is safe to call while already starting', async () => {
+      const app = new App(mockClientId, { logger: mockLogger });
+      let resolveInitialize: () => void = () => {};
+      teamsJsInitializeMock.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveInitialize = resolve;
+        })
+      );
+
+      // start first initialization, this will be pending until the captured promise is resolved
+      const initialization = app.start();
+      expect(mockLogger.debug).toHaveBeenLastCalledWith('app starting');
+
+      // start second initialization, this will log and return immediately
+      await app.start();
+      expect(mockLogger.debug).toHaveBeenLastCalledWith('app already starting');
+
+      // at this point we're still initializing teams-js
+      expect(teamsJsInitializeMock).toHaveBeenCalledTimes(1);
+      expect(msalCreateNPCAppMock).toHaveBeenCalledTimes(0);
+      expect(app.startedAt).toBeUndefined();
+      expect(app.msalInstance).toBeUndefined();
+
+      // complete initialization
+      resolveInitialize?.();
+      await initialization;
+
+      // all set up
+      expect(mockLogger.debug).toHaveBeenLastCalledWith('app started');
+      expect(msalCreateNPCAppMock).toHaveBeenCalledTimes(1);
+      expect(app.startedAt).toEqual(mockDate);
+      expect(app.msalInstance).toBeDefined();
+    });
+  });
+
+  describe('exec', () => {
+    it('should throw if not started', async () => {
+      const app = new App(mockClientId);
+      await expect(app.exec('myFunction')).rejects.toThrow('App not started');
+    });
+
+    it('should invoke a remote function', async () => {
+      httpClientPostMock.mockResolvedValue({
+        data: 'mock result',
+      });
+      const app = new App(mockClientId, { logger: mockLogger, tenantId: mockAppTenantId });
+      await app.start();
+      const result = await app.exec('myFunction', { arg1: 'value1' });
+
+      expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
+      expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
+        app.msalInstance,
+        undefined,
+        app.log
+      );
+      expect(httpClientPostMock).toHaveBeenCalledTimes(1);
+      expect(httpClientPostMock).toHaveBeenCalledWith(
+        '/api/functions/myFunction',
+        { arg1: 'value1' },
+        {
+          headers: {
+            authorization: `Bearer ${mockAccessToken}`,
+            'x-spark-app-client-id': 'mock-client-id',
+            'x-spark-app-id': 'mock-app-id',
+            'x-spark-app-session-id': 'mock-session-id',
+            'x-spark-app-tenant-id': 'mock-app-tenant-id',
+            'x-spark-channel-id': 'mock-channel-id',
+            'x-spark-chat-id': 'mock-chat-id',
+            'x-spark-meeting-id': 'mock-meeting-id',
+            'x-spark-message-id': 'mock-parent-message-id',
+            'x-spark-page-id': 'mock-page-id',
+            'x-spark-sub-page-id': 'mock-sub-page-id',
+            'x-spark-team-id': undefined,
+            'x-spark-tenant-id': 'mock-tenant-id',
+            'x-spark-user-id': 'mock-user-id',
+          },
+        }
+      );
+      expect(result).toEqual('mock result');
+    });
+
+    it('should invoke a remote function with custom token request', async () => {
+      httpClientPostMock.mockResolvedValue({
+        data: 'mock result',
+      });
+      const app = new App(mockClientId, { logger: mockLogger });
+      await app.start();
+      await app.exec('myFunction', undefined, {
+        msalTokenRequest: {
+          scopes: ['Analytics.Read'],
+        },
+      });
+
+      expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
+      expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
+        app.msalInstance,
+        { scopes: ['Analytics.Read'] },
+        app.log
+      );
+      expect(httpClientPostMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invoke a remote function with custom headers', async () => {
+      httpClientPostMock.mockResolvedValue({
+        data: 'mock result',
+      });
+      const app = new App(mockClientId, { logger: mockLogger });
+      await app.start();
+      await app.exec('myFunction', undefined, {
+        requestHeaders: {
+          'x-custom-correlation-id': 'gggg-uuuu-iiii-dddd',
+        },
+      });
+
+      expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
+      expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
+        app.msalInstance,
+        undefined,
+        app.log
+      );
+      expect(httpClientPostMock).toHaveBeenCalledTimes(1);
+      expect(httpClientPostMock).toHaveBeenCalledWith('/api/functions/myFunction', undefined, {
+        headers: expect.objectContaining({
+          'x-custom-correlation-id': 'gggg-uuuu-iiii-dddd',
+        }),
+      });
+    });
+  });
+});

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -1,41 +1,61 @@
 import * as http from '@microsoft/spark.common/http';
 import { ILogger, ConsoleLogger } from '@microsoft/spark.common/logging';
-import { Credentials } from '@microsoft/spark.api';
 
-import * as window from './window';
-import { Context, mapContext } from './context';
+import * as teamsJs from '@microsoft/teams-js';
+import * as msal from '@azure/msal-browser';
+import { acquireMsalAccessToken, buildMsalConfig } from './msalUtils';
 
-export type AppOptions = Partial<Credentials> & {
+export type MsalOptions = {
   /**
-   * the app base url
+   * Optional MSAL configuration. This parameter is used to construct an MSAL instance in order
+   * to make authenticated function calls. If omitted, a default configuration is created.
+   */
+  readonly configuration?: msal.Configuration;
+  /**
+   * Default token request options used when acquiring a token.
+   */
+  readonly defaultSilentRequest?: msal.SilentRequest;
+};
+
+export type AppOptions = {
+  /**
+   * The app base url.
    */
   readonly baseUrl?: string;
 
+  /** App tenant ID */
+  readonly tenantId?: string;
+
   /**
-   * logger instance to use
+   * Logger instance to use.
    */
   readonly logger?: ILogger;
-};
-
-type AppConnect = {
-  /**
-   * the app id
-   */
-  readonly id: string;
 
   /**
-   * the app name
+   * Options to control how MSAL is initialized and used.
    */
-  readonly name: {
-    readonly short: string;
-    readonly full: string;
-  };
+  readonly msalOptions?: MsalOptions;
 };
+
+type AppState =
+  | {
+      phase: 'stopped' | 'starting';
+      startedAt?: never;
+      msalInstance?: never;
+      context?: never;
+    }
+  | {
+      phase: 'started';
+      startedAt: Date;
+      msalInstance: msal.IPublicClientApplication;
+      context: teamsJs.app.Context;
+    };
 
 export class App {
   readonly options: AppOptions;
   readonly http: http.Client;
-  readonly parent: window.Client;
+  readonly clientId: string;
+  protected _state: AppState = { phase: 'stopped' };
 
   /**
    * the apps logger
@@ -46,138 +66,100 @@ export class App {
   protected _log: ILogger;
 
   /**
-   * the app id
+   * the date/time when the app was successfully started.
    */
-  get id() {
-    return this._id;
+  get startedAt() {
+    return this._state?.startedAt;
   }
-  protected _id?: string;
 
-  /**
-   * the app name
-   */
-  get name() {
-    return this._name;
+  /** the msal instance used in this app. undefined until the app is started. */
+  get msalInstance() {
+    return this._state.msalInstance;
   }
-  protected _name?: string;
 
-  /**
-   * the app/window context
-   */
-  get context() {
-    if (!this._context) {
-      throw new Error('app not connected');
+  constructor(clientId: string, options: AppOptions = {}) {
+    if (!clientId) {
+      throw new Error('Invalid client ID.');
     }
 
-    return this._context;
-  }
-  protected _context?: Context;
-
-  /**
-   * the date/time when the app
-   * successfully connected
-   */
-  get connectedAt() {
-    return this._connectedAt;
-  }
-  protected _connectedAt?: Date;
-
-  /**
-   * the sdk runtime
-   */
-  get runtime() {
-    if (!this._runtime) {
-      throw new Error('app not connected');
-    }
-
-    return this._runtime;
-  }
-  protected _runtime?: window.Runtime;
-
-  constructor(options?: AppOptions) {
-    this.options = options || {};
+    this.clientId = clientId;
+    this.options = options;
     this._log = options?.logger || new ConsoleLogger('@spark/client');
     this.http = new http.Client({ baseUrl: options?.baseUrl });
-    this.parent = new window.Client(this.log);
   }
 
   /**
-   * connect to the host app
+   * Starts the library and initializes the dependent teams-js and MSAL libraries.
+   * @returns A promise that will be fulfilled when the app has started, or
+   *          rejected if the initialization fails or times out.
    */
-  async connect() {
-    if (this.connectedAt) {
-      return this.context;
+  async start(): Promise<void> {
+    if (this._state.phase !== 'stopped') {
+      this._log.debug(`app already ${this._state.phase}`);
+      return;
     }
 
-    const res = await this.http.get<AppConnect>('/');
-    this._id = res.data.id;
-    this._name = res.data.name.short;
+    this._log.debug('app starting');
+    this._state = { phase: 'starting' };
 
-    if (this._name) {
-      this._log = this.options.logger || new ConsoleLogger(`@spark/${this._name}`);
-    }
+    await teamsJs.app.initialize();
+    const context = await teamsJs.app.getContext();
 
-    const { runtime } = await this.parent.initialize();
-    this._runtime = runtime;
+    const msalConfig =
+      this.options.msalOptions?.configuration ?? buildMsalConfig(this.clientId, this._log);
+    const msalInstance = await msal.createNestablePublicClientApplication(msalConfig);
+    await msalInstance.initialize();
 
-    const context = await this.parent.getContext();
-    this._context = mapContext(context);
-
-    this._connectedAt = new Date();
-    return this.context;
+    this._state = { phase: 'started', msalInstance, context, startedAt: new Date() };
+    this._log.debug('app started');
   }
 
   /**
-   * execute a server-side function
-   * @param name the unique function name
-   * @param data the data to send
-   * @returns the function response
+   * Execute a server-side function
+   * @param name The unique function name
+   * @param data The data to send
+   * @param options Options
+   * @param options.msalTokenRequest Optional MSAL token request.
+   * If omitted, a default token request is used.
+   * @param options.requestHeaders Optional additional request headers.
+   * @returns The function response
    */
-  async exec<T = any>(name: string, data?: any) {
+  async exec<T = unknown>(
+    name: string,
+    data?: unknown,
+    options?: { msalTokenRequest?: msal.SilentRequest; requestHeaders?: Record<string, string> }
+  ): Promise<T> {
+    if (this._state.phase !== 'started') {
+      throw new Error('App not started');
+    }
+
+    const { context } = this._state;
+    const accessToken = await acquireMsalAccessToken(
+      this._state.msalInstance,
+      options?.msalTokenRequest ?? this.options.msalOptions?.defaultSilentRequest,
+      this._log
+    );
+
     const res = await this.http.post<T>(`/api/functions/${name}`, data, {
       headers: {
-        'x-spark-app-id': this.context.app.id,
-        'x-spark-app-session-id': this.context.app.sessionId,
-        'x-spark-app-client-id': this.options.clientId,
-        'x-spark-app-client-secret':
-          'clientSecret' in this.options ? this.options.clientSecret : undefined,
-        'x-spark-app-tenant-id': 'tenantId' in this.options ? this.options.tenantId : undefined,
-        'x-spark-tenant-id': this.context.user?.tenant?.id,
-        'x-spark-user-id': this.context.user?.id,
-        'x-spark-team-id': this.context.team?.internalId,
-        'x-spark-message-id': this.context.app.parentMessageId,
-        'x-spark-channel-id': this.context.channel?.id,
-        'x-spark-chat-id': this.context.chat?.id,
-        'x-spark-meeting-id': this.context.meeting?.id,
-        'x-spark-page-id': this.context.page.id,
-        'x-spark-sub-page-id': this.context.page.subPageId,
+        'x-spark-app-id': context.app.appId?.toString(),
+        'x-spark-app-session-id': context.app.sessionId,
+        'x-spark-app-client-id': this.clientId,
+        'x-spark-app-tenant-id': this.options.tenantId,
+        'x-spark-tenant-id': context.user?.tenant?.id,
+        'x-spark-user-id': context.user?.id,
+        'x-spark-team-id': context.team?.internalId,
+        'x-spark-message-id': context.app.parentMessageId,
+        'x-spark-channel-id': context.channel?.id,
+        'x-spark-chat-id': context.chat?.id,
+        'x-spark-meeting-id': context.meeting?.id,
+        'x-spark-page-id': context.page.id,
+        'x-spark-sub-page-id': context.page.subPageId,
+        authorization: `Bearer ${accessToken}`,
+        ...(options?.requestHeaders ?? {}),
       },
     });
 
     return res.data;
-  }
-
-  /**
-   * get the auth user
-   */
-  async getUser() {
-    const res = await this.parent.authentication.getUser();
-    return res;
-  }
-
-  /**
-   * get the auth users token
-   */
-  async getUserToken(params?: window.AuthTokenRequestParams) {
-    const token = await this.parent.authentication.getToken(params);
-    return token;
-  }
-
-  /**
-   * get chat members
-   */
-  async getChatMembers() {
-    const members = await this.parent.conversation.getMembers();
-    return members;
   }
 }

--- a/packages/client/src/msalUtils.spec.ts
+++ b/packages/client/src/msalUtils.spec.ts
@@ -1,0 +1,159 @@
+import { InteractionRequiredAuthError, LogLevel } from '@azure/msal-browser';
+
+import { acquireMsalAccessToken, buildMsalConfig, fallbackSilentRequestScopes } from './msalUtils';
+
+const mockClientId = 'mock-client-id';
+const mockLogger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  log: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+
+describe('msalUtils', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fallbackSilentRequestScopes', () => {
+    it('should contain the expected scopes', () => {
+      expect(fallbackSilentRequestScopes).toEqual(['User.Read']);
+    });
+  });
+
+  describe('buildMsalConfig', () => {
+    it('should return a valid MSAL configuration', () => {
+      const config = buildMsalConfig(mockClientId, mockLogger);
+
+      expect(config).toEqual({
+        auth: {
+          clientId: mockClientId,
+          authority: '',
+          redirectUri: '/',
+          postLogoutRedirectUri: '/',
+        },
+        system: {
+          loggerOptions: {
+            piiLoggingEnabled: false,
+            loggerCallback: expect.any(Function),
+          },
+        },
+      });
+    });
+
+    it('forwards MSAL log entries to the appropriate logger method', () => {
+      const config = buildMsalConfig(mockClientId, mockLogger);
+
+      const loggerCallback = config.system?.loggerOptions?.loggerCallback;
+      expect(loggerCallback).toBeDefined();
+
+      expect(mockLogger.error).not.toHaveBeenCalled();
+      loggerCallback?.(LogLevel.Error, 'Test error message', false);
+      expect(mockLogger.error).toHaveBeenCalledWith('Test error message');
+
+      expect(mockLogger.info).not.toHaveBeenCalled();
+      loggerCallback?.(LogLevel.Info, 'Test info message', false);
+      expect(mockLogger.info).toHaveBeenCalledWith('Test info message');
+
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+      loggerCallback?.(LogLevel.Verbose, 'Test verbose message', false);
+      expect(mockLogger.debug).toHaveBeenCalledWith('Test verbose message');
+
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+      loggerCallback?.(LogLevel.Warning, 'Test warning message', false);
+      expect(mockLogger.warn).toHaveBeenCalledWith('Test warning message');
+    });
+
+    it('ignores MSAL log entries with unexpected log level', () => {
+      const config = buildMsalConfig(mockClientId, mockLogger);
+
+      const loggerCallback = config.system?.loggerOptions?.loggerCallback;
+      expect(loggerCallback).toBeDefined();
+
+      loggerCallback?.(LogLevel.Trace, 'Test warning message', false);
+
+      expect(mockLogger.error).not.toHaveBeenCalled();
+      expect(mockLogger.info).not.toHaveBeenCalled();
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('acquireMsalAccessToken', () => {
+    const accessToken = 'access token';
+
+    it('should call acquireTokenSilent with the correct request', async () => {
+      const acquireTokenSilent = jest.fn().mockResolvedValue({ accessToken });
+      const acquireTokenPopup = jest.fn().mockRejectedValue(new Error('Oh noes!'));
+      const request = { scopes: ['whatever', 'whatever.else'] };
+
+      const result = await acquireMsalAccessToken(
+        { acquireTokenSilent, acquireTokenPopup },
+        request,
+        mockLogger
+      );
+
+      expect(acquireTokenSilent).toHaveBeenCalledWith(request);
+      expect(acquireTokenPopup).not.toHaveBeenCalled();
+      expect(result).toEqual(accessToken);
+    });
+
+    it('should call acquireTokenSilent with default request', async () => {
+      const acquireTokenSilent = jest.fn().mockResolvedValue({ accessToken });
+      const acquireTokenPopup = jest.fn().mockRejectedValue(new Error('Oh noes!'));
+
+      const result = await acquireMsalAccessToken(
+        { acquireTokenSilent, acquireTokenPopup },
+        undefined,
+        mockLogger
+      );
+
+      expect(acquireTokenSilent).toHaveBeenCalledWith({
+        scopes: [...fallbackSilentRequestScopes],
+      });
+      expect(acquireTokenPopup).not.toHaveBeenCalled();
+      expect(result).toEqual(accessToken);
+    });
+
+    it('should throw if acquireTokenSilent fails and is not an InteractionRequiredAuthError', async () => {
+      const acquireTokenSilent = jest.fn().mockRejectedValue(new Error('Oh noes!'));
+      const acquireTokenPopup = jest.fn().mockResolvedValue({ accessToken });
+
+      await expect(
+        acquireMsalAccessToken({ acquireTokenSilent, acquireTokenPopup }, undefined, mockLogger)
+      ).rejects.toThrow('Oh noes!');
+      expect(acquireTokenSilent).toHaveBeenCalledTimes(1);
+      expect(acquireTokenPopup).not.toHaveBeenCalled();
+    });
+
+    it('should call acquireTokenPopup if acquireTokenSilent fails with InteractionRequiredAuthError', async () => {
+      const interactionError = new InteractionRequiredAuthError('Interaction required');
+      const acquireTokenSilent = jest.fn().mockRejectedValue(interactionError);
+      const acquireTokenPopup = jest.fn().mockResolvedValue({ accessToken });
+
+      const result = await acquireMsalAccessToken(
+        { acquireTokenSilent, acquireTokenPopup },
+        undefined,
+        mockLogger
+      );
+
+      expect(acquireTokenSilent).toHaveBeenCalledTimes(1);
+      expect(acquireTokenPopup).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(accessToken);
+    });
+
+    it('should throw if acquireTokenPopup fails', async () => {
+      const interactionError = new InteractionRequiredAuthError('Interaction required');
+      const acquireTokenSilent = jest.fn().mockRejectedValue(interactionError);
+      const acquireTokenPopup = jest.fn().mockRejectedValue(new Error('Oh noes!'));
+
+      await expect(
+        acquireMsalAccessToken({ acquireTokenSilent, acquireTokenPopup }, undefined, mockLogger)
+      ).rejects.toThrow('Oh noes!');
+      expect(acquireTokenSilent).toHaveBeenCalledTimes(1);
+      expect(acquireTokenPopup).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/client/src/msalUtils.ts
+++ b/packages/client/src/msalUtils.ts
@@ -1,0 +1,90 @@
+import * as msal from '@azure/msal-browser';
+
+import { ILogger } from '@microsoft/spark.common/logging';
+
+/**
+ * Token request scopes used as a fallback when acquiring a token silently.
+ */
+export const fallbackSilentRequestScopes: readonly string[] = ['User.Read'] as const;
+
+/**
+ * Builds a default MSAL configuration for the specified client ID.
+ * @param clientId The application client ID.
+ * @param logger The logger instance to use for logging MSAL events.
+ * @returns A default MSAL configuration object suitable for creating a
+ * @see{IPublicClientApplication} instance for a multi-tenant application.
+ */
+export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configuration => {
+  return {
+    auth: {
+      clientId,
+      authority: '',
+      redirectUri: '/',
+      postLogoutRedirectUri: '/',
+    },
+    system: {
+      loggerOptions: {
+        piiLoggingEnabled: false,
+        loggerCallback: (level, message) => {
+          switch (level) {
+            case msal.LogLevel.Error:
+              logger.error(message);
+              return;
+            case msal.LogLevel.Info:
+              logger.info(message);
+              return;
+            case msal.LogLevel.Verbose:
+              logger.debug(message);
+              return;
+            case msal.LogLevel.Warning:
+              logger.warn(message);
+              return;
+            default:
+              return;
+          }
+        },
+      },
+    },
+  };
+};
+
+/**
+ * Acquires an access token using MSAL. It first attempts to acquire the token silently,
+ * and if that fails with an InteractionRequiredAuthError, it falls back to acquiring the
+ * token via a popup.
+ * @param msalInstance The MSAL instance to use for acquiring the token.
+ * @param request The token request object. If not provided, a default request with fallback scopes is used.
+ * @param logger The logger instance to use for logging errors.
+ * @returns A promise that resolves to the acquired access token.
+ */
+export const acquireMsalAccessToken = async (
+  msalInstance: Pick<msal.IPublicClientApplication, 'acquireTokenSilent' | 'acquireTokenPopup'>,
+  request: msal.SilentRequest | undefined,
+  logger: ILogger
+): Promise<string> => {
+  request = request ?? {
+    scopes: [...fallbackSilentRequestScopes],
+  };
+
+  try {
+    const response = await msalInstance.acquireTokenSilent(request);
+    return response.accessToken;
+  } catch (ex) {
+    // InteractionRequiredAuthError indicates that the user may not have consented to the requested
+    // scope yet -- for this, we can fall back on acquireTokenPopup instead.
+    const tryAcquireTokenPopup = ex instanceof msal.InteractionRequiredAuthError;
+    if (!tryAcquireTokenPopup) {
+      logger.error('acquireTokenSilent failed', ex);
+      throw ex;
+    }
+  }
+
+  try {
+    logger.debug('acquireTokenSilent failed; trying acquireTokenPopup');
+    const response = await msalInstance.acquireTokenPopup(request);
+    return response.accessToken;
+  } catch (ex) {
+    logger.error('acquireTokenPopup failed', ex);
+    throw ex;
+  }
+};

--- a/samples/tab/src/Tab/App.tsx
+++ b/samples/tab/src/Tab/App.tsx
@@ -5,29 +5,28 @@ import { ConsoleLogger } from '@microsoft/spark.common';
 import './App.css';
 
 export default function App() {
-  const [context, setContext] = React.useState<client.Context>();
+  const [greeting, setGreeting] = React.useState('');
 
   React.useEffect(() => {
     (async () => {
-      const app = new client.App({
-        clientId: import.meta.env.VITE_CLIENT_ID,
-        clientSecret: import.meta.env.VITE_CLIENT_SECRET,
-        tenantId: import.meta.env.VITE_TENANT_ID,
+      const clientId = import.meta.env.VITE_CLIENT_ID;
+      const tenantId = import.meta.env.VITE_TENANT_ID;
+      const app = new client.App(clientId, {
+        tenantId,
         logger: new ConsoleLogger('@samples/tab', { level: 'debug' }),
       });
 
-      const context = await app.connect();
-      setContext(context);
+      await app.start();
 
-      const res = await app.exec('hello-world', { hello: 'world' });
-      app.log.info(res);
+      const result = await app.exec<string>('hello-world');
+      setGreeting(result);
     })();
   }, []);
 
   return (
     <div className="App">
       <pre>
-        <code>{JSON.stringify(context, null, 2)}</code>
+        <code>{greeting}</code>
       </pre>
     </div>
   );

--- a/samples/tab/src/index.ts
+++ b/samples/tab/src/index.ts
@@ -12,6 +12,7 @@ const app = new App({
 app.tab('test', path.resolve('dist/client'));
 app.function('hello-world', async ({ log, data }) => {
   log.info(data);
+  return 'Hello, world!';
 });
 
 (async () => {


### PR DESCRIPTION
This PR updates the Client package to take a dependency on MSAL and teams-js. This in order to generate a bearer token to include in function calls, for the server side to validate. In addition, minor adjustments are done to the TTK configuration and tab sample in order to showcase the feature.

Token validation is not included in this PR, that'll come separately. 

How tested:
 - Building the cli, app and client libraries locally, I used the cli to create a new Embed app from the Tab template
 - In the newly created app, after pointing the app & client dependencies to my local build, simply run in Chrome using TTK
 - The app is built, deployed, starts up. When I install the app in Teams and open the tab, I'm prompted to consent to the user.read scope in order to create a token. After consenting, the app successfully calls the `hello-world` function and prints the response.
 - I see in the network tab that a valid bearer token is included in the function call, and the other custom spark request headers are included as expected.
 - 