### PR TITLE
Fix explicit Oauth flow (remove support for multiple connections)

### DIFF
--- a/packages/apps/src/app.oauth.ts
+++ b/packages/apps/src/app.oauth.ts
@@ -14,9 +14,9 @@ export async function onTokenExchange(
 ) {
   const { api, activity, log } = ctx;
 
-  if (this.defaultConnectionName !== activity.value.connectionName) {
+  if (this.oauth.defaultConnectionName !== activity.value.connectionName) {
     log.warn(
-      `default connection name "${this.defaultConnectionName}" does not match activity connection name "${activity.value.connectionName}"`
+      `default connection name "${this.oauth.defaultConnectionName}" does not match activity connection name "${activity.value.connectionName}"`
     );
   }
 
@@ -74,7 +74,7 @@ export async function onVerifyState(
     const token = await api.users.token.get({
       channelId: activity.channelId,
       userId: activity.from.id,
-      connectionName: this.defaultConnectionName,
+      connectionName: this.oauth.defaultConnectionName,
       code: activity.value.state,
     });
 

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -32,7 +32,7 @@ export async function $process(this: App, sender: ISender, event: IActivityEvent
     const res = await this.api.users.token.get({
       channelId: activity.channelId,
       userId: activity.from.id,
-      connectionName: this.options.oauth?.graph || 'graph',
+      connectionName: this.oauth.defaultConnectionName,
     });
 
     userToken = res.token;
@@ -113,7 +113,7 @@ export async function $process(this: App, sender: ISender, event: IActivityEvent
     ref,
     storage: this.storage,
     isSignedIn: !!userToken,
-    connectionName: this.defaultConnectionName,
+    connectionName: this.oauth.defaultConnectionName,
   });
 
   if (routes.length === 0) {

--- a/packages/apps/src/app.process.ts
+++ b/packages/apps/src/app.process.ts
@@ -1,10 +1,10 @@
 import { ActivityLike, ConversationReference, isInvokeResponse } from '@microsoft/spark.api';
 
-import { App } from './app';
 import { ApiClient } from './api';
-import { ISender } from './types';
+import { App } from './app';
 import { ActivityContext, IActivityContext } from './contexts';
 import { IActivityEvent } from './events';
+import { ISender } from './types';
 
 /**
  * activity handler called when an inbound activity is received
@@ -113,6 +113,7 @@ export async function $process(this: App, sender: ISender, event: IActivityEvent
     ref,
     storage: this.storage,
     isSignedIn: !!userToken,
+    connectionName: this.defaultConnectionName,
   });
 
   if (routes.length === 0) {

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -20,7 +20,7 @@ import { AppClient } from './api';
 import { IEvents } from './events';
 import * as manifest from './manifest';
 import * as middleware from './middleware';
-import { OAuthSettings } from './oauth';
+import { DEFAULT_OAUTH_SETTINGS, OAuthSettings } from './oauth';
 import { HttpPlugin } from './plugins';
 import { Router } from './router';
 import { IPlugin } from './types';
@@ -71,12 +71,6 @@ export type AppOptions = Partial<Credentials> & {
    * Activity Options
    */
   readonly activity?: AppActivityOptions;
-
-  /**
-   * The default connection name to use for the app
-   * @default 'graph'
-   */
-  readonly defaultConnectionName?: string;
 };
 
 export type AppActivityOptions = {
@@ -111,13 +105,6 @@ export class App {
   readonly client: http.Client;
   readonly storage: IStorage;
   readonly credentials?: Credentials;
-  /**
-   * The name of the default connection to use for the app
-   * @default 'graph'
-   * The plan is to support multiple connections, but we are
-   * waiting on the Teams Client to support the protocol.
-   */
-  readonly defaultConnectionName: string;
 
   /**
    * the apps id
@@ -131,6 +118,13 @@ export class App {
    */
   get name() {
     return this.tokens.bot?.appDisplayName || this.tokens.graph?.appDisplayName;
+  }
+
+  get oauth() {
+    return {
+      ...this.options.oauth,
+      ...DEFAULT_OAUTH_SETTINGS,
+    };
   }
 
   /**
@@ -182,7 +176,6 @@ export class App {
     this.log = this.options.logger || new ConsoleLogger('@spark/app');
     this.storage = this.options.storage || new LocalStorage();
     this._manifest = this.options.manifest || {};
-    this.defaultConnectionName = this.options.defaultConnectionName ?? 'graph';
     if (!options.client) {
       this.client = new http.Client({
         headers: {

--- a/packages/apps/src/oauth.ts
+++ b/packages/apps/src/oauth.ts
@@ -1,8 +1,12 @@
 export type OAuthSettings = {
   /**
    * the OAuth connection name to use for
-   * authentication with MSGraph
+   * authentication
    * @default `graph`
    */
-  readonly graph?: string;
+  readonly defaultConnectionName?: string;
+};
+
+export const DEFAULT_OAUTH_SETTINGS: Required<OAuthSettings> = {
+  defaultConnectionName: 'graph',
 };


### PR DESCRIPTION
- Currently our oauth flow works well for SSO, but not for explicit Oauth.
- In explicit Oauth, the value for the `tokenExchangeUrl` is set to blank
![image](https://github.com/user-attachments/assets/672b3bcc-89da-40a3-aa01-4386193e7d4a)
- This means that this is NOT an SSO. When this is the case, the `onTokenExchange` will not be called. And this is the function which sets the storage value to indicate that an Oauth is actually happening. The `onVerifyState` checks if this value is present or not before proceeding.
- In this PR, we are (temporarily) removing the ability to have multiple connections in favor of simplicity. This means that we don't need to store connectionName anywhere and we can use this `defaultConnectionName`.
- I am working on getting stateless oauth prioritized, until this I've raised this issue to track it (https://github.com/microsoft/spark.js/issues/125).