### PR TITLE
Fix task module typings

### DIFF
--- a/packages/api/src/models/task-module/task-module-continue-response.ts
+++ b/packages/api/src/models/task-module/task-module-continue-response.ts
@@ -9,6 +9,7 @@ import { TaskModuleTaskInfo } from './task-module-task-info';
  * @extends TaskModuleResponseBase
  */
 export type TaskModuleContinueResponse = TaskModuleResponseBase & {
+  type: 'continue';
   /**
    * @member {TaskModuleTaskInfo} [value] The JSON for the Adaptive card to
    * appear in the task module.

--- a/packages/api/src/models/task-module/task-module-message-response.ts
+++ b/packages/api/src/models/task-module/task-module-message-response.ts
@@ -8,6 +8,7 @@ import { TaskModuleResponseBase } from './task-module-response-base';
  * @extends TaskModuleResponseBase
  */
 export type TaskModuleMessageResponse = TaskModuleResponseBase & {
+  type: 'message';
   /**
    * @member {string} [value] Teams will display the value of value in a popup
    * message box.


### PR DESCRIPTION
These add explicit literal types to TaskModuleContinueResponse and TaskModuleMessageResponse. Without this the discriminated union for TaskModuleResponse doesn't work.

https://github.com/microsoft/spark.js/blob/7401a5362a34b7e1ef3b93db23e866fd776454c0/packages/api/src/models/task-module/task-module-response.ts#L16