### PR TITLE
[Client] kebab-case msal-utils

### DIFF
--- a/packages/client/src/app.spec.ts
+++ b/packages/client/src/app.spec.ts
@@ -3,8 +3,8 @@ const msalCreateNPCAppMock = jest.fn();
 const msalInitializeMock = jest.fn();
 const httpClientPostMock = jest.fn();
 
-import * as MsalUtils from './msalUtils';
 import { App } from './app';
+import * as MsalUtils from './msal-utils';
 
 jest.mock('@microsoft/teams-js', () => {
   return {

--- a/packages/client/src/app.ts
+++ b/packages/client/src/app.ts
@@ -1,9 +1,9 @@
+import * as msal from '@azure/msal-browser';
 import * as http from '@microsoft/spark.common/http';
 import { ILogger, ConsoleLogger } from '@microsoft/spark.common/logging';
-
 import * as teamsJs from '@microsoft/teams-js';
-import * as msal from '@azure/msal-browser';
-import { acquireMsalAccessToken, buildMsalConfig } from './msalUtils';
+
+import { acquireMsalAccessToken, buildMsalConfig } from './msal-utils';
 
 export type MsalOptions = {
   /**

--- a/packages/client/src/msal-utils.spec.ts
+++ b/packages/client/src/msal-utils.spec.ts
@@ -1,6 +1,6 @@
 import { InteractionRequiredAuthError, LogLevel } from '@azure/msal-browser';
 
-import { acquireMsalAccessToken, buildMsalConfig, fallbackSilentRequestScopes } from './msalUtils';
+import { acquireMsalAccessToken, buildMsalConfig, fallbackSilentRequestScopes } from './msal-utils';
 
 const mockClientId = 'mock-client-id';
 const mockLogger = {

--- a/packages/client/src/msal-utils.ts
+++ b/packages/client/src/msal-utils.ts
@@ -1,5 +1,4 @@
 import * as msal from '@azure/msal-browser';
-
 import { ILogger } from '@microsoft/spark.common/logging';
 
 /**


### PR DESCRIPTION
This PR renames the  msalUtils files to msal-utils to follow existing naming convention. Also, sorts a few imports.

How tested:
 - unit tests pass
 - `npm run build` builds
 