### PR TITLE
[Client, Apps] Validate entra app token when remote functions are invoked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6658,7 +6658,6 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -6669,7 +6668,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6782,7 +6780,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/inquirer": {
@@ -6865,7 +6862,6 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.9.tgz",
       "integrity": "sha512-uoe+GxEuHbvy12OUQct2X9JenKM3qAscquYymuQN4fMWG9DBQtykrQEFcAbVACF7qaLw9BePSodUL0kquqBJpQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*",
@@ -6892,7 +6888,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -6944,14 +6939,12 @@
       "version": "6.9.18",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
       "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -6984,7 +6977,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -6995,7 +6987,6 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
       "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -13456,6 +13447,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -13637,6 +13637,47 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwks-rsa": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.0.tgz",
+      "integrity": "sha512-PwchfHcQK/5PSydeKCs1ylNym0w/SSv8a62DgHJ//7x2ZclCoinlsjAfDxAAbpoTPybOum/Jgy+vkvMmKz89Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "^4.17.20",
+        "@types/jsonwebtoken": "^9.0.4",
+        "debug": "^4.3.4",
+        "jose": "^4.15.4",
+        "limiter": "^1.1.5",
+        "lru-memoizer": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/jws": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
@@ -13719,6 +13760,11 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/limiter": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13761,6 +13807,12 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
     "node_modules/lodash.get": {
@@ -13980,6 +14032,34 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lru-memoizer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-memoizer/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "0.447.0",
@@ -20264,6 +20344,8 @@
         "axios": "^1.8.2",
         "cors": "^2.8.5",
         "express": "^4.21.0",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.2.0",
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -41,6 +41,8 @@
     "axios": "^1.8.2",
     "cors": "^2.8.5",
     "express": "^4.21.0",
+    "jsonwebtoken": "^9.0.2",
+    "jwks-rsa": "^3.2.0",
     "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {

--- a/packages/apps/src/app.embed.ts
+++ b/packages/apps/src/app.embed.ts
@@ -20,7 +20,7 @@ export function func<TData>(
     `/api/functions/${name}`,
     withClientAuth({
       logger: log,
-      entraTokenValidator: this.entryTokenValidator,
+      entraTokenValidator: this.entraTokenValidator,
       ...this.credentials,
     }),
     async (req: ClientAuthRequest, res) => {

--- a/packages/apps/src/app.embed.ts
+++ b/packages/apps/src/app.embed.ts
@@ -20,6 +20,7 @@ export function func<TData>(
     `/api/functions/${name}`,
     withClientAuth({
       logger: log,
+      entraTokenValidator: this.entryTokenValidator,
       ...this.credentials,
     }),
     async (req: ClientAuthRequest, res) => {

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -105,7 +105,7 @@ export class App {
   readonly client: http.Client;
   readonly storage: IStorage;
   readonly credentials?: Credentials;
-  readonly entryTokenValidator?: middleware.EntraTokenValidator;
+  readonly entraTokenValidator?: middleware.EntraTokenValidator;
 
   /**
    * the apps id
@@ -237,7 +237,7 @@ export class App {
     }
 
     if (clientId) {
-      this.entryTokenValidator = new middleware.EntraTokenValidator({
+      this.entraTokenValidator = new middleware.EntraTokenValidator({
         clientId,
         tenantId: tenantId || 'common',
       });

--- a/packages/apps/src/app.ts
+++ b/packages/apps/src/app.ts
@@ -105,6 +105,7 @@ export class App {
   readonly client: http.Client;
   readonly storage: IStorage;
   readonly credentials?: Credentials;
+  readonly entryTokenValidator?: middleware.EntraTokenValidator;
 
   /**
    * the apps id
@@ -233,6 +234,13 @@ export class App {
         tenantId,
         token,
       };
+    }
+
+    if (clientId) {
+      this.entryTokenValidator = new middleware.EntraTokenValidator({
+        clientId,
+        tenantId: tenantId || 'common',
+      });
     }
 
     // add/validate plugins

--- a/packages/apps/src/middleware/entra-token-validator.spec.ts
+++ b/packages/apps/src/middleware/entra-token-validator.spec.ts
@@ -1,0 +1,529 @@
+import jwt from 'jsonwebtoken';
+
+import * as EntraTokenValidatorComponent from './entra-token-validator';
+const { EntraTokenValidator, getJwksClient } = EntraTokenValidatorComponent;
+
+const mockDate = new Date('2025-10-01T00:00:00Z');
+const mockClientId = 'mock-client-id';
+const mockTenantId = 'mock-tenant-id';
+const mockLogger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  log: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+const mockToken = {
+  header: {
+    kid: 'mock-kid',
+    alg: 'RS256',
+    typ: 'JWT',
+  },
+  signature: 'john hancock',
+  payload: {
+    iat: Math.floor(mockDate.getTime() / 1000 - 60),
+    exp: Math.floor(mockDate.getTime() / 1000 + 60),
+    scp: 'access_as_user',
+    aud: `api://${mockClientId}`,
+    iss: `https://login.microsoftonline.com/${mockTenantId}/v2.0`,
+  },
+};
+
+jest.mock('jsonwebtoken', () => {
+  return { ...jest.requireActual('jsonwebtoken'), decode: jest.fn(), verify: jest.fn() };
+});
+
+describe('getJwksClient', () => {
+  it('should return a JWKS client with the correct URI', () => {
+    const jwksClient = getJwksClient({
+      jwksUri: 'https://login.microsoftonline.com/mock-tenant-id/discovery/v2.0/keys',
+    });
+    expect(jwksClient).toBeDefined();
+    expect(jwksClient).toHaveProperty('getSigningKey', expect.any(Function));
+    expect(jwksClient).toHaveProperty('options', {
+      cache: true,
+      jwksUri: 'https://login.microsoftonline.com/mock-tenant-id/discovery/v2.0/keys',
+      rateLimit: false,
+      timeout: 30000,
+    });
+  });
+});
+
+describe('EntraTokenValidator', () => {
+  let getJwksClientSpy: jest.SpyInstance;
+  const mockGetPublicKey = jest.fn();
+  const mockDecodeToken = jwt.decode as jest.Mock;
+  const mockVerifyToken = jwt.verify as jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(mockDate);
+    getJwksClientSpy = jest
+      .spyOn(EntraTokenValidatorComponent, 'getJwksClient')
+      .mockImplementation(() => {
+        return {
+          getSigningKey: jest.fn().mockResolvedValue({
+            getPublicKey: mockGetPublicKey.mockReturnValue('mockedPublicKey'),
+          }),
+          getSigningKeys: jest.fn(),
+          getKeys: jest.fn(),
+        };
+      });
+
+    mockDecodeToken.mockImplementation(() => mockToken);
+    mockVerifyToken.mockImplementation(() => mockToken);
+    mockGetPublicKey.mockImplementation(
+      jest.fn().mockResolvedValue(() => {
+        return {
+          publicKey: 'mock-public-key',
+          rsaPublicKey: 'mock-rsa-public-key',
+        };
+      })
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  describe('constructor', () => {
+    it('can create an EntraTokenValidator without options', () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+      expect(getJwksClientSpy).toHaveBeenCalledTimes(1);
+      expect(getJwksClientSpy).toHaveBeenCalledWith({
+        jwksUri: 'https://login.microsoftonline.com/mock-tenant-id/discovery/v2.0/keys',
+      });
+      expect(entraTokenValidator.clientId).toEqual(mockClientId);
+      expect(entraTokenValidator.tenantId).toEqual(mockTenantId);
+      expect(entraTokenValidator.validIssuerTenantIds).toEqual([mockTenantId]);
+    });
+
+    it.each`
+      allowedTenantIds          | description
+      ${undefined}              | ${'no allowed tenantIds'}
+      ${[]}                     | ${'empty list of allowed tenantIds'}
+      ${['tenant1', 'tenant2']} | ${'two allowed tenantIds'}
+    `(
+      'can create an EntraTokenValidator for a single tenant app with options.allowedTenantIds set to $description',
+      ({ allowedTenantIds }) => {
+        const entraTokenValidator = new EntraTokenValidator({
+          clientId: mockClientId,
+          tenantId: mockTenantId,
+          options: { allowedTenantIds },
+        });
+        expect(getJwksClientSpy).toHaveBeenCalledTimes(1);
+        expect(getJwksClientSpy).toHaveBeenCalledWith({
+          jwksUri: 'https://login.microsoftonline.com/mock-tenant-id/discovery/v2.0/keys',
+        });
+        expect(entraTokenValidator.clientId).toEqual(mockClientId);
+        expect(entraTokenValidator.tenantId).toEqual(mockTenantId);
+        expect(entraTokenValidator.validIssuerTenantIds).toEqual([mockTenantId]);
+      }
+    );
+
+    it.each`
+      tenantId           | allowedTenantIds          | validIssuerTenantIds      | description
+      ${'common'}        | ${undefined}              | ${[]}                     | ${'no allowed tenantIds'}
+      ${'common'}        | ${[]}                     | ${[]}                     | ${'empty list of allowed tenantIds'}
+      ${'common'}        | ${['tenant1', 'tenant2']} | ${['tenant1', 'tenant2']} | ${'two allowed tenantIds'}
+      ${'organizations'} | ${['tenant1', 'tenant2']} | ${['tenant1', 'tenant2']} | ${'two allowed tenantIds'}
+      ${'consumers'}     | ${['tenant1', 'tenant2']} | ${['tenant1', 'tenant2']} | ${'two allowed tenantIds'}
+    `(
+      'can create an EntraTokenValidator for tenantId "$tenantId" with $description',
+      ({ tenantId, allowedTenantIds, validIssuerTenantIds }) => {
+        const entraTokenValidator = new EntraTokenValidator({
+          clientId: mockClientId,
+          tenantId,
+          options: { allowedTenantIds },
+        });
+        expect(getJwksClientSpy).toHaveBeenCalledTimes(1);
+        expect(getJwksClientSpy).toHaveBeenCalledWith({
+          jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
+        });
+        expect(entraTokenValidator.clientId).toEqual(mockClientId);
+        expect(entraTokenValidator.tenantId).toEqual(tenantId);
+        expect(entraTokenValidator.validIssuerTenantIds).toEqual(validIssuerTenantIds);
+      }
+    );
+  });
+
+  describe('getTokenPayload', () => {
+    it('should return the token payload', () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+      const tokenPayload = entraTokenValidator.getTokenPayload(mockToken);
+      expect(tokenPayload).toEqual(mockToken.payload);
+    });
+
+    it('returns null when token payload is not an object', () => {
+      const token = {
+        ...mockToken,
+        payload: 'not-an-object',
+      };
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const tokenPayload = entraTokenValidator.getTokenPayload(token);
+      expect(tokenPayload).toBeNull();
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validateAccessToken', () => {
+    it('should return null if no token is provided', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, '');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith('No token provided');
+    });
+
+    it('should catch and log exception if the token cannot be decoded', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const exception = new Error('Invalid token exception');
+      mockDecodeToken.mockImplementation(() => {
+        throw exception;
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'invalid-token');
+      expect(result).toBeNull();
+      expect(mockDecodeToken).toHaveBeenCalledWith('invalid-token', { complete: true });
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(exception);
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to decode the access token');
+    });
+
+    it('should return null if public key can not be found', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+      mockGetPublicKey.mockReturnValue(null);
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to find public key for the key identifier "mock-kid"'
+      );
+    });
+
+    it('should return null if public key can not be fetched', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const exception = new Error('Public key fetch error');
+      mockGetPublicKey.mockImplementation(() => {
+        throw exception;
+      });
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(exception);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Failed to find public key for the key identifier "mock-kid"'
+      );
+    });
+
+    it('should return null if token signature can not be verified', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const exception = new Error('Token signature verification error');
+      mockVerifyToken.mockImplementation(() => {
+        throw exception;
+      });
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(exception);
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the token signature');
+    });
+  });
+
+  describe('validateAccessTokenClaims', () => {
+    it.each`
+      tokenScp             | requiredScope        | description
+      ${undefined}         | ${undefined}         | ${'no scope is present or required'}
+      ${'access_as_user'}  | ${undefined}         | ${'no scope is required'}
+      ${'access_as_santa'} | ${'access_as_santa'} | ${'the requested scope is present'}
+    `('returns a token when $description', async ({ tokenScp, requiredScope }) => {
+      const token = {
+        ...mockToken,
+        payload: { ...mockToken.payload, scp: tokenScp },
+      };
+      mockVerifyToken.mockImplementation(() => token);
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(
+        mockLogger,
+        'bearer-token',
+        requiredScope
+      );
+      expect(result).toEqual(token);
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it.each`
+      audience
+      ${mockClientId}
+      ${`api://${mockClientId}`}
+    `('returns a token when audience is $audience', async ({ audience }) => {
+      const token = {
+        ...mockToken,
+        payload: { ...mockToken.payload, aud: audience },
+      };
+      mockVerifyToken.mockImplementation(() => token);
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toEqual(token);
+      expect(mockLogger.error).not.toHaveBeenCalled();
+    });
+
+    it.each`
+      tenantId        | allowedTenantIds                      | description
+      ${'common'}     | ${undefined}                          | ${'allowedTenantIds is undefined'}
+      ${mockTenantId} | ${['unrelated-tenant']}               | ${'allowedTenantIds is set to some unrelated tenant'}
+      ${'common'}     | ${['unrelated-tenant', mockTenantId]} | ${'allowedTenantIds includes the token issuer'}
+    `(
+      'returns a token when tenantId is $tenantId and $description',
+      async ({ tenantId, allowedTenantIds }) => {
+        const token = {
+          ...mockToken,
+          payload: {
+            ...mockToken.payload,
+            iss: `https://login.microsoftonline.com/${mockTenantId}/`,
+          },
+        };
+        mockVerifyToken.mockImplementation(() => token);
+
+        const entraTokenValidator = new EntraTokenValidator({
+          clientId: mockClientId,
+          tenantId,
+          options: { allowedTenantIds },
+        });
+
+        const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+        expect(result).toEqual(token);
+        expect(mockLogger.error).not.toHaveBeenCalled();
+      }
+    );
+
+    it('should return null if token payload is missing', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: undefined,
+      }));
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith('Invalid token payload.');
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if token issued-at value is missing', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, iat: undefined },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith('The token is expired or not yet valid.');
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if token issued-at value is in the future', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, iat: mockDate.getTime() / 1000 + 1 },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith('The token is expired or not yet valid.');
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if token expires-at value is missing', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, exp: undefined },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith('The token is expired or not yet valid.');
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if token expires-at value is in the past', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, exp: mockDate.getTime() / 1000 - 1 },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith('The token is expired or not yet valid.');
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if audience is missing', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, aud: undefined },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'The token is not issued for the expected audience.'
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if audience is unexpected', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, aud: 'api://wrong-client-id' },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'The token is not issued for the expected audience.'
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if issuer is missing', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: { ...mockToken.payload, iss: undefined },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith('Invalid token issuer.');
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if issuer is unexpected', async () => {
+      mockVerifyToken.mockImplementation(() => ({
+        ...mockToken,
+        payload: {
+          ...mockToken.payload,
+          iss: 'https://login.microsoftonline.com/some-other-tenant/v2.0',
+        },
+      }));
+
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(mockLogger, 'bearer-token');
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'The token is issued by unexpected tenant: https://login.microsoftonline.com/some-other-tenant/v2.0'
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+
+    it('should return null if token is issued for the wrong scope', async () => {
+      const entraTokenValidator = new EntraTokenValidator({
+        clientId: mockClientId,
+        tenantId: mockTenantId,
+      });
+
+      const result = await entraTokenValidator.validateAccessToken(
+        mockLogger,
+        'bearer-token',
+        'access_as_santa_claus'
+      );
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledTimes(2);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'The token is not issued for the required scope: access_as_santa_claus'
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to validate the access token claims');
+    });
+  });
+});

--- a/packages/apps/src/middleware/entra-token-validator.ts
+++ b/packages/apps/src/middleware/entra-token-validator.ts
@@ -1,0 +1,221 @@
+import jwt, { type JwtPayload } from 'jsonwebtoken';
+import jwksClient, { JwksClient } from 'jwks-rsa';
+
+import { ILogger } from '@microsoft/spark.common';
+
+/**
+ * Entra token validator parameters
+ */
+type EntraTokenValidatorParams = {
+  /**
+   *  App tenant ID. Used to find public keys to validate token signature, and to validate issuer for single-tenant apps.
+   *  This can be 'common', 'organization', or 'consumers' for a multi-tenant app, or a specific tenant ID for a single-tenant app.
+   */
+  tenantId: string;
+  /** App client ID. Used to validate token audience. */
+  clientId: string;
+  options?: {
+    /**
+     * For multi-tenant apps that only allows sign-in from specific tenants, this is the list of allowed tenant IDs.
+     * If empty or not provided, any tenant is considered valid.
+     * This is ignored for single-tenant apps.
+     */
+    allowedTenantIds?: string[];
+  };
+};
+
+export const getJwksClient = (options: jwksClient.Options): JwksClient => jwksClient(options);
+
+/**
+ * And Entra token validator that can validate access tokens issued by Microsoft Entra for app specific use.
+ */
+export class EntraTokenValidator {
+  readonly tenantId: string;
+  readonly clientId: string;
+  readonly validIssuerTenantIds: string[];
+  private keyClient: JwksClient;
+
+  constructor({ tenantId, clientId, options }: EntraTokenValidatorParams) {
+    this.tenantId = tenantId;
+    this.clientId = clientId;
+
+    // single-tenant applications only allow tokens issued by this app's tenant
+    // multi tenant applications allow tokens issued by any tenant, unless the
+    // allowedTenantIds option is provided to limit the set of allowed issuers.
+    const isMultiTenant = ['common', 'organizations', 'consumers'].some((val) => tenantId === val);
+    this.validIssuerTenantIds = isMultiTenant ? (options?.allowedTenantIds ?? []) : [this.tenantId];
+
+    this.keyClient = getJwksClient({
+      jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
+    });
+  }
+
+  /**
+   * Validates a JWT access token
+   * @param {ILogger} logger The logger to use.
+   * @param {string} rawAccessToken The access token as a string.
+   * @param { string | undefined } requiredScope If provided, the token will only be considered valid if issued for this scope.
+   * @returns {Promise<jwt.Jwt | null>} The validated token if the signature is valid and the claims are valid.
+   */
+  async validateAccessToken(
+    logger: ILogger,
+    rawAccessToken: string,
+    requiredScope?: string
+  ): Promise<jwt.Jwt | null> {
+    if (!rawAccessToken) {
+      logger.error('No token provided');
+      return null;
+    }
+
+    const token = this.decodeToken(logger, rawAccessToken);
+    if (!token) {
+      logger.error('Failed to decode the access token');
+      return null;
+    }
+
+    const publicKey = await this.getPublicKey(logger, token.header);
+    if (!publicKey) {
+      logger.error(`Failed to find public key for the key identifier "${token.header.kid}"`);
+      return null;
+    }
+
+    const validatedToken = this.validateTokenSignature(logger, rawAccessToken, publicKey);
+    if (!validatedToken) {
+      logger.error('Failed to validate the token signature');
+      return null;
+    }
+
+    if (!this.validateAccessTokenClaims(logger, validatedToken, requiredScope)) {
+      logger.error('Failed to validate the access token claims');
+      return null;
+    }
+
+    return validatedToken;
+  }
+
+  getTokenPayload(token: jwt.Jwt): JwtPayload | null {
+    return token.payload instanceof Object ? token.payload : null;
+  }
+
+  /**
+   * Validates the token claims: that it's valid for the intended purpose, it's not expired, it has the right audience & issuer,
+   * it's issued for the requisite scope.
+   * @param {ILogger} logger The logger to use.
+   * @param {jwt.Jwt} token The token to validate.
+   * @param { string | undefined } requiredScope If provided, the token will only be considered valid if issued for this scope.
+   * @returns {boolean} True if the claims validation passed.
+   */
+  private validateAccessTokenClaims(
+    logger: ILogger,
+    token: jwt.Jwt,
+    requiredScope?: string
+  ): boolean {
+    const payload = this.getTokenPayload(token);
+    if (!payload) {
+      logger.error('Invalid token payload.');
+      return false;
+    }
+
+    // validate iat (issued at) and exp (expiration) fields.
+    // these are expressed as number of seconds since Unix epoch.
+    const now = Math.round(new Date().getTime() / 1000.0);
+    const checkTimestamp = payload.iat && payload.iat <= now && payload.exp && payload.exp >= now;
+
+    if (!checkTimestamp) {
+      logger.error('The token is expired or not yet valid.');
+      return false;
+    }
+
+    // validate audience
+    const checkAudience = payload.aud === this.clientId || payload.aud === `api://${this.clientId}`;
+    if (!checkAudience) {
+      logger.error('The token is not issued for the expected audience.');
+      return false;
+    }
+
+    const tokenIssuer = payload.iss;
+    if (!tokenIssuer) {
+      logger.error('Invalid token issuer.');
+      return false;
+    }
+
+    // validate token issuer
+    //  - if this is a single-tenant application, validate that the token is issued by the expected tenant
+    //  - if this is a multi-tenant application that only allows sign-in from specific tenants, validate that
+    //    the token is issued by one of those
+    //  - if this is a multi-tenant that does not limit sign-in to specific tenants, any issuer is considered valid.
+    const checkIssuer =
+      !this.validIssuerTenantIds.length ||
+      this.validIssuerTenantIds.some((tenantId) =>
+        tokenIssuer.startsWith(`https://login.microsoftonline.com/${tenantId}/`)
+      );
+    if (!checkIssuer) {
+      logger.error(`The token is issued by unexpected tenant: ${payload.iss}`);
+      return false;
+    }
+
+    // validate that the token is issued for the required scope
+    const checkRequiredScope = !requiredScope || payload.scp?.includes(requiredScope);
+    if (!checkRequiredScope) {
+      logger.error(`The token is not issued for the required scope: ${requiredScope}`);
+      return false;
+    }
+
+    // all checks passed
+    return true;
+  }
+
+  /**
+   * Decodes an access token without verifying if the signature is valid.
+   * @param {ILogger} logger The logger to use.
+   * @param {string} rawAccessToken the raw access token.
+   * @returns {jwt.JWT | null} A decoded token if the raw access token is well formed.
+   */
+  private decodeToken(logger: ILogger, rawAccessToken: string): jwt.Jwt | null {
+    try {
+      return jwt.decode(rawAccessToken, { complete: true });
+    } catch (error) {
+      logger.error(error);
+      return null;
+    }
+  }
+
+  /**
+   * Gets the public key from the key identifier in a token header
+   * @param {ILogger} logger The logger to use.
+   * @param {jwt.JwtHeader} header the token header
+   * @returns {Promise<string | undefined>} the public key corresponding to the header key identifier, if available
+   */
+  private async getPublicKey(
+    logger: ILogger,
+    header: Pick<jwt.JwtHeader, 'kid'>
+  ): Promise<string | null> {
+    try {
+      const signingKey = await this.keyClient.getSigningKey(header.kid);
+      return signingKey.getPublicKey() ?? null;
+    } catch (error) {
+      logger.error(error);
+      return null;
+    }
+  }
+
+  /**
+   * Decodes the access token and verifies it against the public key
+   * @param {ILogger} logger The logger to use.
+   * @param {string} rawAccessToken the raw access token.
+   * @param {string} publicKey the public key to verify signature against.
+   * @returns {Promise<jwt.JWT | null>} A decoded token if the raw token is well formed and the signature is valid.
+   */
+  private validateTokenSignature(
+    logger: ILogger,
+    rawAccessToken: string,
+    publicKey: string
+  ): jwt.Jwt | null {
+    try {
+      return jwt.verify(rawAccessToken, publicKey, { complete: true });
+    } catch (error) {
+      logger.error(error);
+      return null;
+    }
+  }
+}

--- a/packages/apps/src/middleware/index.ts
+++ b/packages/apps/src/middleware/index.ts
@@ -1,2 +1,3 @@
-export * from './with-client-auth';
+export { EntraTokenValidator } from './entra-token-validator';
 export * from './strip-mentions-text';
+export * from './with-client-auth';

--- a/packages/apps/src/middleware/with-client-auth.spec.ts
+++ b/packages/apps/src/middleware/with-client-auth.spec.ts
@@ -1,0 +1,156 @@
+import { withClientAuth } from './with-client-auth';
+
+const mockLogger = {
+  error: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  log: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+};
+const tokenValidatorMock = {
+  validateAccessToken: jest.fn(),
+  getTokenPayload: jest.fn(),
+};
+const mockRequestHeaders = {
+  Authorization: 'Bearer valid-token',
+  'X-Spark-App-Session-Id': 'test-app-session-id',
+  'X-Spark-Page-Id': 'test-page-id',
+  'X-Spark-Channel-Id': 'test-channel-id',
+  'X-Spark-Chat-Id': 'test-chat-id',
+  'X-Spark-Meeting-Id': 'test-meeting-id',
+  'X-Spark-Message-Id': 'test-message-id',
+  'X-Spark-Sub-Page-Id': 'test-sub-page-id',
+  'X-Spark-Team-Id': 'test-team-id',
+} as const;
+
+describe('withClientAuth Middleware', () => {
+  let mockRequest: any;
+  let mockResponse: any;
+  let mockNext: jest.Mock;
+  const mockRequestStatus = jest.fn();
+  const mockRequestStatusSend = jest.fn();
+
+  beforeEach(() => {
+    mockRequest = {
+      header: (headerName: keyof typeof mockRequestHeaders) => mockRequestHeaders[headerName],
+      context: {},
+    };
+    mockResponse = {
+      status: mockRequestStatus.mockReturnValue({ send: mockRequestStatusSend }),
+    };
+    mockNext = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set context and call next if authentication is successful', async () => {
+    // Mock a valid authentication scenario
+    tokenValidatorMock.validateAccessToken.mockResolvedValue({});
+    tokenValidatorMock.getTokenPayload.mockReturnValue({
+      appId: 'test-app-id',
+      tid: 'test-tenant-id',
+      oid: 'test-user-id',
+    });
+
+    const handleRequest = withClientAuth({
+      logger: mockLogger,
+      entraTokenValidator: tokenValidatorMock,
+    });
+    await handleRequest(mockRequest, mockResponse, mockNext);
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockResponse.status).not.toHaveBeenCalled();
+    expect(mockRequest.context).toEqual({
+      appId: 'test-app-id',
+      appSessionId: 'test-app-session-id',
+      authToken: 'valid-token',
+      channelId: 'test-channel-id',
+      chatId: 'test-chat-id',
+      meetingId: 'test-meeting-id',
+      messageId: 'test-message-id',
+      pageId: 'test-page-id',
+      subPageId: 'test-sub-page-id',
+      teamId: 'test-team-id',
+      tenantId: 'test-tenant-id',
+      userId: 'test-user-id',
+    });
+  });
+
+  it.each`
+    missingHeader
+    ${'X-Spark-App-Session-Id'}
+    ${'X-Spark-Page-Id'}
+  `('should return 401 if the $missingHeader header is missing', async ({ missingHeader }) => {
+    mockRequest.header = (headerName: keyof typeof mockRequestHeaders) =>
+      headerName === missingHeader ? undefined : mockRequestHeaders[headerName];
+
+    const handleRequest = withClientAuth({
+      logger: mockLogger,
+      entraTokenValidator: tokenValidatorMock,
+    });
+    await handleRequest(mockRequest, mockResponse, mockNext);
+
+    expect(mockRequestStatus).toHaveBeenCalledWith(401);
+    expect(mockRequestStatusSend).toHaveBeenCalledWith('unauthorized');
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it.each`
+    authorizationHeader         | expected
+    ${undefined}                | ${''}
+    ${'Bearer '}                | ${''}
+    ${'Bearer invalid data '}   | ${''}
+    ${'Bearer   invalid-data '} | ${''}
+    ${'pop valid-token'}        | ${''}
+    ${'Bearer valid-token'}     | ${'valid-token'}
+    ${'BEARER valid-token'}     | ${'valid-token'}
+    ${'bearer valid-token'}     | ${'valid-token'}
+  `(
+    'should invoke validateAccessToken with "$expected" when authorization header value is "$authorizationHeader"',
+    async ({ authorizationHeader, expected }) => {
+      mockRequest.header = (headerName: keyof typeof mockRequestHeaders) =>
+        headerName === 'Authorization' ? authorizationHeader : mockRequestHeaders[headerName];
+
+      const handleRequest = withClientAuth({
+        logger: mockLogger,
+        entraTokenValidator: tokenValidatorMock,
+      });
+      await handleRequest(mockRequest, mockResponse, mockNext);
+      expect(tokenValidatorMock.validateAccessToken).toHaveBeenCalledWith(mockLogger, expected);
+    }
+  );
+
+  it('should return 401 if the token validator is missing', async () => {
+    const handleRequest = withClientAuth({
+      logger: mockLogger,
+      entraTokenValidator: undefined,
+    });
+    await handleRequest(mockRequest, mockResponse, mockNext);
+
+    expect(mockRequestStatus).toHaveBeenCalledWith(401);
+    expect(mockRequestStatusSend).toHaveBeenCalledWith('unauthorized');
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 if token validation fails', async () => {
+    const handleRequest = withClientAuth({
+      logger: mockLogger,
+      entraTokenValidator: tokenValidatorMock,
+    });
+
+    tokenValidatorMock.validateAccessToken.mockResolvedValue(null);
+
+    await handleRequest(mockRequest, mockResponse, mockNext);
+
+    expect(mockLogger.debug).toHaveBeenCalledWith('unauthorized');
+    const send = jest.fn();
+    const response: any = {
+      status: jest.fn().mockReturnValue({ send }),
+    };
+    await handleRequest(mockRequest, response, mockNext);
+    expect(mockNext).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apps/src/middleware/with-client-auth.ts
+++ b/packages/apps/src/middleware/with-client-auth.ts
@@ -4,8 +4,10 @@ import { ILogger } from '@microsoft/spark.common';
 import { Credentials } from '@microsoft/spark.api';
 
 import { IClientContext } from '../contexts';
+import { EntraTokenValidator } from './entra-token-validator';
 
 export type WithClientAuthParams = Partial<Credentials> & {
+  entraTokenValidator?: Pick<EntraTokenValidator, 'validateAccessToken' | 'getTokenPayload'>;
   readonly logger: ILogger;
 };
 
@@ -14,45 +16,43 @@ export type ClientAuthRequest = express.Request & {
 };
 
 export function withClientAuth(params: WithClientAuthParams) {
+  const entraTokenValidator = params.entraTokenValidator;
   const log = params.logger;
-  const clientId = params.clientId;
-  const tenantId = 'tenantId' in params ? params.tenantId : undefined;
 
-  return (req: ClientAuthRequest, res: express.Response, next: express.NextFunction) => {
-    const appClientId = req.header('X-Spark-App-Client-Id');
-    const appTenantId = req.header('X-Spark-App-Tenant-Id');
+  return async (req: ClientAuthRequest, res: express.Response, next: express.NextFunction) => {
     const appSessionId = req.header('X-Spark-App-Session-Id');
     const pageId = req.header('X-Spark-Page-Id');
     const authorization = req.header('Authorization')?.split(' ');
     const authToken =
       authorization?.length === 2 && authorization[0].toLowerCase() === 'bearer'
         ? authorization[1]
-        : undefined;
+        : '';
 
-    if (
-      !pageId ||
-      !appSessionId ||
-      appClientId !== clientId ||
-      (tenantId && appTenantId !== tenantId)
-    ) {
+    const validatedToken = !entraTokenValidator
+      ? null
+      : await entraTokenValidator.validateAccessToken(log, authToken);
+
+    if (!pageId || !appSessionId || !validatedToken || !entraTokenValidator) {
       log.debug('unauthorized');
       res.status(401).send('unauthorized');
       return;
     }
 
+    const tokenPayload = entraTokenValidator.getTokenPayload(validatedToken);
+
     req.context = {
-      pageId,
+      appId: tokenPayload?.['appId'],
       appSessionId,
-      appId: req.header('X-Spark-App-Id'),
-      tenantId: req.header('X-Spark-Tenant-Id'),
-      userId: req.header('X-Spark-User-Id'),
-      teamId: req.header('X-Spark-Team-Id'),
-      messageId: req.header('X-Spark-Message-Id'),
+      authToken,
       channelId: req.header('X-Spark-Channel-Id'),
       chatId: req.header('X-Spark-Chat-Id'),
       meetingId: req.header('X-Spark-Meeting-Id'),
+      messageId: req.header('X-Spark-Message-Id'),
+      pageId,
       subPageId: req.header('X-Spark-Sub-Page-Id'),
-      authToken,
+      teamId: req.header('X-Spark-Team-Id'),
+      tenantId: tokenPayload?.['tid'],
+      userId: tokenPayload?.['oid'],
     };
 
     next();

--- a/packages/cli/configs/ttk/embed/aad.manifest.json.hbs
+++ b/packages/cli/configs/ttk/embed/aad.manifest.json.hbs
@@ -2,7 +2,10 @@
     "id": "$\{{AAD_APP_OBJECT_ID}}",
     "appId": "$\{{BOT_ID}}",
     "displayName": "{{ toPascalCase name }}$\{{APP_NAME_SUFFIX}}",
-    "identifierUris": [],
+    "identifierUris": [
+        "api://$\{{BOT_ID}}"
+    ],
+
     "signInAudience": "AzureADMultipleOrgs",
     "api": {
         "requestedAccessTokenVersion": 2,

--- a/packages/client/src/app.spec.ts
+++ b/packages/client/src/app.spec.ts
@@ -256,7 +256,7 @@ describe('App', () => {
       expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
       expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
         app.msalInstance,
-        undefined,
+        { scopes: ['api://mock-client-id/access_as_user'] },
         app.log
       );
       expect(httpClientPostMock).toHaveBeenCalledTimes(1);
@@ -266,10 +266,7 @@ describe('App', () => {
         {
           headers: {
             authorization: `Bearer ${mockAccessToken}`,
-            'x-spark-app-client-id': 'mock-client-id',
-            'x-spark-app-id': 'mock-app-id',
             'x-spark-app-session-id': 'mock-session-id',
-            'x-spark-app-tenant-id': 'mock-app-tenant-id',
             'x-spark-channel-id': 'mock-channel-id',
             'x-spark-chat-id': 'mock-chat-id',
             'x-spark-meeting-id': 'mock-meeting-id',
@@ -277,8 +274,6 @@ describe('App', () => {
             'x-spark-page-id': 'mock-page-id',
             'x-spark-sub-page-id': 'mock-sub-page-id',
             'x-spark-team-id': undefined,
-            'x-spark-tenant-id': 'mock-tenant-id',
-            'x-spark-user-id': 'mock-user-id',
           },
         }
       );
@@ -293,14 +288,33 @@ describe('App', () => {
       await app.start();
       await app.exec('myFunction', undefined, {
         msalTokenRequest: {
-          scopes: ['Analytics.Read'],
+          scopes: ['my_custom_scope'],
         },
       });
 
       expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
       expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
         app.msalInstance,
-        { scopes: ['Analytics.Read'] },
+        { scopes: ['my_custom_scope'] },
+        app.log
+      );
+      expect(httpClientPostMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should invoke a remote function with custom permission', async () => {
+      httpClientPostMock.mockResolvedValue({
+        data: 'mock result',
+      });
+      const app = new App(mockClientId, { logger: mockLogger });
+      await app.start();
+      await app.exec('myFunction', undefined, {
+        permission: 'my_custom_permission',
+      });
+
+      expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
+      expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
+        app.msalInstance,
+        { scopes: ['api://mock-client-id/my_custom_permission'] },
         app.log
       );
       expect(httpClientPostMock).toHaveBeenCalledTimes(1);
@@ -321,7 +335,7 @@ describe('App', () => {
       expect(acquireMsalAccessTokenSpy).toHaveBeenCalledTimes(1);
       expect(acquireMsalAccessTokenSpy).toHaveBeenLastCalledWith(
         app.msalInstance,
-        undefined,
+        { scopes: ['api://mock-client-id/access_as_user'] },
         app.log
       );
       expect(httpClientPostMock).toHaveBeenCalledTimes(1);

--- a/packages/client/src/msal-utils.ts
+++ b/packages/client/src/msal-utils.ts
@@ -2,9 +2,17 @@ import * as msal from '@azure/msal-browser';
 import { ILogger } from '@microsoft/spark.common/logging';
 
 /**
- * Token request scopes used as a fallback when acquiring a token silently.
+ * Gets a silent request used to acquire an Entra access token for invoking remote functions on behalf of a user.
+ * @param remoteClientId The client ID of the remote application.
+ * @param permission The permission to request. Defaults to 'access_as_user'.
+ * @returns
  */
-export const fallbackSilentRequestScopes: readonly string[] = ['User.Read'] as const;
+export const getStandardExecSilentRequest = (
+  remoteClientId: string,
+  permission = 'access_as_user'
+): msal.SilentRequest => ({
+  scopes: [`api://${remoteClientId}/${permission}`],
+});
 
 /**
  * Builds a default MSAL configuration for the specified client ID.
@@ -52,19 +60,15 @@ export const buildMsalConfig = (clientId: string, logger: ILogger): msal.Configu
  * and if that fails with an InteractionRequiredAuthError, it falls back to acquiring the
  * token via a popup.
  * @param msalInstance The MSAL instance to use for acquiring the token.
- * @param request The token request object. If not provided, a default request with fallback scopes is used.
+ * @param request The token request object.
  * @param logger The logger instance to use for logging errors.
  * @returns A promise that resolves to the acquired access token.
  */
 export const acquireMsalAccessToken = async (
   msalInstance: Pick<msal.IPublicClientApplication, 'acquireTokenSilent' | 'acquireTokenPopup'>,
-  request: msal.SilentRequest | undefined,
+  request: msal.SilentRequest,
   logger: ILogger
 ): Promise<string> => {
-  request = request ?? {
-    scopes: [...fallbackSilentRequestScopes],
-  };
-
   try {
     const response = await msalInstance.acquireTokenSilent(request);
     return response.accessToken;


### PR DESCRIPTION
This apps an entra token validator class that uses jwks-rsa and jsonwebtoken to validate the entra auth token when remote functions are invoked.

How tested:
 - extensive unit tests
 - scaffolded a new tab+bot project with TTK and the spark embed config, it just works out of the box.
 - in a test app, played around with a number of token validation scenarios to ensure that they work when expected, and rejected when appropriate: single-tenant app, multi-tenant with and without tenant restrictions, different scopes, expiration, audiences, token purposes, etc. 