### PR TITLE
Bump manifest schema version to v20

### DIFF
--- a/packages/cli/templates/typescript/ai/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/ai/appPackage/manifest.json.hbs
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
-  "manifestVersion": "1.15",
+  "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
   "packageName": "com.package.{{ toDotCase name }}",
   "name": {

--- a/packages/cli/templates/typescript/ai/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/ai/appPackage/manifest.json.hbs
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
-  "packageName": "com.package.{{ toDotCase name }}",
   "name": {
     "short": "{{ toKebabCase name }}-$\{{APP_NAME_SUFFIX}}",
     "full": "{{ capitalize name }}"

--- a/packages/cli/templates/typescript/ai/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/ai/appPackage/manifest.json.hbs
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
   "manifestVersion": "1.15",
   "id": "$\{{TEAMS_APP_ID}}",

--- a/packages/cli/templates/typescript/echo/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/echo/appPackage/manifest.json.hbs
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
-  "manifestVersion": "1.15",
+  "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
   "packageName": "com.package.{{ toDotCase name }}",
   "name": {

--- a/packages/cli/templates/typescript/echo/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/echo/appPackage/manifest.json.hbs
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
-  "packageName": "com.package.{{ toDotCase name }}",
   "name": {
     "short": "{{ toKebabCase name }}-$\{{APP_NAME_SUFFIX}}",
     "full": "{{ capitalize name }}"

--- a/packages/cli/templates/typescript/echo/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/echo/appPackage/manifest.json.hbs
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
   "manifestVersion": "1.15",
   "id": "$\{{TEAMS_APP_ID}}",

--- a/packages/cli/templates/typescript/graph/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/graph/appPackage/manifest.json.hbs
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
-  "manifestVersion": "1.15",
+  "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
   "packageName": "com.package.{{ toDotCase name }}",
   "name": {

--- a/packages/cli/templates/typescript/graph/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/graph/appPackage/manifest.json.hbs
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
-  "packageName": "com.package.{{ toDotCase name }}",
   "name": {
     "short": "{{ toKebabCase name }}-$\{{APP_NAME_SUFFIX}}",
     "full": "{{ capitalize name }}"

--- a/packages/cli/templates/typescript/graph/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/graph/appPackage/manifest.json.hbs
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
   "manifestVersion": "1.15",
   "id": "$\{{TEAMS_APP_ID}}",

--- a/packages/cli/templates/typescript/mcp/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/mcp/appPackage/manifest.json.hbs
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
-  "manifestVersion": "1.15",
+  "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
   "packageName": "com.package.{{ toDotCase name }}",
   "name": {

--- a/packages/cli/templates/typescript/mcp/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/mcp/appPackage/manifest.json.hbs
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
-  "packageName": "com.package.{{ toDotCase name }}",
   "name": {
     "short": "{{ toKebabCase name }}-$\{{APP_NAME_SUFFIX}}",
     "full": "{{ capitalize name }}"

--- a/packages/cli/templates/typescript/mcp/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/mcp/appPackage/manifest.json.hbs
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
   "manifestVersion": "1.15",
   "id": "$\{{TEAMS_APP_ID}}",

--- a/packages/cli/templates/typescript/tab/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/tab/appPackage/manifest.json.hbs
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
-  "manifestVersion": "1.15",
+  "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
   "packageName": "com.package.{{ toDotCase name }}",
   "name": {

--- a/packages/cli/templates/typescript/tab/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/tab/appPackage/manifest.json.hbs
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "manifestVersion": "1.20",
   "id": "$\{{TEAMS_APP_ID}}",
-  "packageName": "com.package.{{ toDotCase name }}",
   "name": {
     "short": "{{ toKebabCase name }}-$\{{APP_NAME_SUFFIX}}",
     "full": "{{ capitalize name }}"

--- a/packages/cli/templates/typescript/tab/appPackage/manifest.json.hbs
+++ b/packages/cli/templates/typescript/tab/appPackage/manifest.json.hbs
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.15/MicrosoftTeams.schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json",
   "version": "1.0.0",
   "manifestVersion": "1.15",
   "id": "$\{{TEAMS_APP_ID}}",


### PR DESCRIPTION
It was pointing to an old schema. here is the current schema:
https://developer.microsoft.com/json-schemas/teams/v1.20/MicrosoftTeams.schema.json

Tested locally, and it seems to work